### PR TITLE
홈 화면 최근 검색 셀 구성

### DIFF
--- a/GIL/GIL.xcodeproj/project.pbxproj
+++ b/GIL/GIL.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		5806472A2BCD147A00FB7310 /* UIImage+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 580647292BCD147A00FB7310 /* UIImage+Extension.swift */; };
+		5810DE202BE1F78400180BFB /* MappinImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5810DE1F2BE1F78400180BFB /* MappinImageView.swift */; };
 		58368EFA2BD51957009E008C /* BasicLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58368EF92BD51957009E008C /* BasicLabel.swift */; };
 		58368EFC2BD536B8009E008C /* AlertService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58368EFB2BD536B8009E008C /* AlertService.swift */; };
 		58368EFE2BD75E9C009E008C /* FirebaseAuth+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58368EFD2BD75E9C009E008C /* FirebaseAuth+Extension.swift */; };
@@ -86,6 +87,7 @@
 
 /* Begin PBXFileReference section */
 		580647292BCD147A00FB7310 /* UIImage+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+Extension.swift"; sourceTree = "<group>"; };
+		5810DE1F2BE1F78400180BFB /* MappinImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MappinImageView.swift; sourceTree = "<group>"; };
 		58368EF92BD51957009E008C /* BasicLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BasicLabel.swift; sourceTree = "<group>"; };
 		58368EFB2BD536B8009E008C /* AlertService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertService.swift; sourceTree = "<group>"; };
 		58368EFD2BD75E9C009E008C /* FirebaseAuth+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FirebaseAuth+Extension.swift"; sourceTree = "<group>"; };
@@ -314,6 +316,7 @@
 				584FA4212BA84254002600F1 /* BasicButton.swift */,
 				58BAC8AF2BCCF59800CDEB1F /* NavigationActionButton.swift */,
 				58368EF92BD51957009E008C /* BasicLabel.swift */,
+				5810DE1F2BE1F78400180BFB /* MappinImageView.swift */,
 			);
 			path = Component;
 			sourceTree = "<group>";
@@ -600,6 +603,7 @@
 				58368F012BD7617D009E008C /* FirebaseAuthError.swift in Sources */,
 				58BAC89B2BC53A4D00CDEB1F /* UIButton+Extension.swift in Sources */,
 				5806472A2BCD147A00FB7310 /* UIImage+Extension.swift in Sources */,
+				5810DE202BE1F78400180BFB /* MappinImageView.swift in Sources */,
 				58BDFBCA2BBA9B27006AC994 /* SignUpViewModel.swift in Sources */,
 				58BDFBC22BB6A748006AC994 /* OSLog+Extension.swift in Sources */,
 				58368F1A2BDE424A009E008C /* PlaceSearchView.swift in Sources */,

--- a/GIL/GIL.xcodeproj/project.pbxproj
+++ b/GIL/GIL.xcodeproj/project.pbxproj
@@ -42,6 +42,7 @@
 		584FA4452BAD6068002600F1 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 584FA4442BAD6068002600F1 /* GoogleService-Info.plist */; };
 		584FA44A2BB15D51002600F1 /* LoginViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 584FA4492BB15D51002600F1 /* LoginViewModel.swift */; };
 		586F030C2BE0C4A2008660A0 /* LanguageCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 586F030B2BE0C4A1008660A0 /* LanguageCode.swift */; };
+		586F030F2BE0D050008660A0 /* PlaceData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 586F030E2BE0D050008660A0 /* PlaceData.swift */; };
 		586F03122BE0FC55008660A0 /* PlaceSearchViewController+LocationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 586F03112BE0FC55008660A0 /* PlaceSearchViewController+LocationService.swift */; };
 		586F03142BE0FCB5008660A0 /* PlaceSearchViewController+SearchBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 586F03132BE0FCB5008660A0 /* PlaceSearchViewController+SearchBar.swift */; };
 		586F03162BE0FD9A008660A0 /* PlaceSearchViewController+UICollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 586F03152BE0FD9A008660A0 /* PlaceSearchViewController+UICollectionView.swift */; };
@@ -117,6 +118,7 @@
 		584FA4442BAD6068002600F1 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		584FA4492BB15D51002600F1 /* LoginViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewModel.swift; sourceTree = "<group>"; };
 		586F030B2BE0C4A1008660A0 /* LanguageCode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LanguageCode.swift; sourceTree = "<group>"; };
+		586F030E2BE0D050008660A0 /* PlaceData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaceData.swift; sourceTree = "<group>"; };
 		586F03112BE0FC55008660A0 /* PlaceSearchViewController+LocationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PlaceSearchViewController+LocationService.swift"; sourceTree = "<group>"; };
 		586F03132BE0FCB5008660A0 /* PlaceSearchViewController+SearchBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PlaceSearchViewController+SearchBar.swift"; sourceTree = "<group>"; };
 		586F03152BE0FD9A008660A0 /* PlaceSearchViewController+UICollectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PlaceSearchViewController+UICollectionView.swift"; sourceTree = "<group>"; };
@@ -250,6 +252,7 @@
 				58BDFB9F2BB16F93006AC994 /* GIL.entitlements */,
 				584FA4192BA7F5E1002600F1 /* Screen */,
 				58DE930B2BDF948100C97575 /* Model */,
+				586F030D2BE0D03D008660A0 /* SwiftData */,
 				584FA4202BA82D26002600F1 /* Component */,
 				584FA4262BA84CF5002600F1 /* Extension */,
 				58368EFF2BD76162009E008C /* Enum */,
@@ -330,6 +333,14 @@
 				58DE930E2BDFA23200C97575 /* UIView+Extension.swift */,
 			);
 			path = Extension;
+			sourceTree = "<group>";
+		};
+		586F030D2BE0D03D008660A0 /* SwiftData */ = {
+			isa = PBXGroup;
+			children = (
+				586F030E2BE0D050008660A0 /* PlaceData.swift */,
+			);
+			path = SwiftData;
 			sourceTree = "<group>";
 		};
 		586F03102BE0FC24008660A0 /* Delegate */ = {
@@ -568,6 +579,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				586F030F2BE0D050008660A0 /* PlaceData.swift in Sources */,
 				58368EFC2BD536B8009E008C /* AlertService.swift in Sources */,
 				584FA41B2BA7F606002600F1 /* LoginViewController.swift in Sources */,
 				58368F032BD80472009E008C /* HomeInteractor.swift in Sources */,
@@ -713,7 +725,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
@@ -771,7 +783,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
@@ -797,6 +809,7 @@
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -830,6 +843,7 @@
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -856,7 +870,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = E98D6ZNGDP;
 				GENERATE_INFOPLIST_FILE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = woojin.GILTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -880,7 +894,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = E98D6ZNGDP;
 				GENERATE_INFOPLIST_FILE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = woojin.GILTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -903,6 +917,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = E98D6ZNGDP;
 				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = woojin.GILUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -925,6 +940,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = E98D6ZNGDP;
 				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = woojin.GILUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/GIL/GIL.xcodeproj/project.pbxproj
+++ b/GIL/GIL.xcodeproj/project.pbxproj
@@ -42,6 +42,9 @@
 		584FA4452BAD6068002600F1 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 584FA4442BAD6068002600F1 /* GoogleService-Info.plist */; };
 		584FA44A2BB15D51002600F1 /* LoginViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 584FA4492BB15D51002600F1 /* LoginViewModel.swift */; };
 		586F030C2BE0C4A2008660A0 /* LanguageCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 586F030B2BE0C4A1008660A0 /* LanguageCode.swift */; };
+		586F03122BE0FC55008660A0 /* PlaceSearchViewController+LocationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 586F03112BE0FC55008660A0 /* PlaceSearchViewController+LocationService.swift */; };
+		586F03142BE0FCB5008660A0 /* PlaceSearchViewController+SearchBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 586F03132BE0FCB5008660A0 /* PlaceSearchViewController+SearchBar.swift */; };
+		586F03162BE0FD9A008660A0 /* PlaceSearchViewController+UICollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 586F03152BE0FD9A008660A0 /* PlaceSearchViewController+UICollectionView.swift */; };
 		58A6808E2BDE7C02004E6706 /* LocationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58A6808D2BDE7C02004E6706 /* LocationService.swift */; };
 		58BAC8972BC52F8500CDEB1F /* UILabel+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58BAC8962BC52F8500CDEB1F /* UILabel+Extension.swift */; };
 		58BAC8992BC5399D00CDEB1F /* UITextField+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58BAC8982BC5399D00CDEB1F /* UITextField+Extension.swift */; };
@@ -114,6 +117,9 @@
 		584FA4442BAD6068002600F1 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		584FA4492BB15D51002600F1 /* LoginViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewModel.swift; sourceTree = "<group>"; };
 		586F030B2BE0C4A1008660A0 /* LanguageCode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LanguageCode.swift; sourceTree = "<group>"; };
+		586F03112BE0FC55008660A0 /* PlaceSearchViewController+LocationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PlaceSearchViewController+LocationService.swift"; sourceTree = "<group>"; };
+		586F03132BE0FCB5008660A0 /* PlaceSearchViewController+SearchBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PlaceSearchViewController+SearchBar.swift"; sourceTree = "<group>"; };
+		586F03152BE0FD9A008660A0 /* PlaceSearchViewController+UICollectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PlaceSearchViewController+UICollectionView.swift"; sourceTree = "<group>"; };
 		58A6808D2BDE7C02004E6706 /* LocationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationService.swift; sourceTree = "<group>"; };
 		58BAC8962BC52F8500CDEB1F /* UILabel+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UILabel+Extension.swift"; sourceTree = "<group>"; };
 		58BAC8982BC5399D00CDEB1F /* UITextField+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITextField+Extension.swift"; sourceTree = "<group>"; };
@@ -201,6 +207,7 @@
 			children = (
 				58368F1B2BDE4650009E008C /* Views */,
 				58DE93072BDF841300C97575 /* Cells */,
+				586F03102BE0FC24008660A0 /* Delegate */,
 				58368F152BDE41FC009E008C /* PlaceSearchViewController.swift */,
 				58368F172BDE4243009E008C /* PlaceSearchViewModel.swift */,
 			);
@@ -323,6 +330,16 @@
 				58DE930E2BDFA23200C97575 /* UIView+Extension.swift */,
 			);
 			path = Extension;
+			sourceTree = "<group>";
+		};
+		586F03102BE0FC24008660A0 /* Delegate */ = {
+			isa = PBXGroup;
+			children = (
+				586F03112BE0FC55008660A0 /* PlaceSearchViewController+LocationService.swift */,
+				586F03132BE0FCB5008660A0 /* PlaceSearchViewController+SearchBar.swift */,
+				586F03152BE0FD9A008660A0 /* PlaceSearchViewController+UICollectionView.swift */,
+			);
+			path = Delegate;
 			sourceTree = "<group>";
 		};
 		58BDFBA02BB2B865006AC994 /* SignUp */ = {
@@ -555,6 +572,7 @@
 				584FA41B2BA7F606002600F1 /* LoginViewController.swift in Sources */,
 				58368F032BD80472009E008C /* HomeInteractor.swift in Sources */,
 				58368F052BD8047E009E008C /* HomePresenter.swift in Sources */,
+				586F03122BE0FC55008660A0 /* PlaceSearchViewController+LocationService.swift in Sources */,
 				58368F162BDE41FC009E008C /* PlaceSearchViewController.swift in Sources */,
 				58BDFBDC2BBEA5D0006AC994 /* HomeView.swift in Sources */,
 				584FA4282BA84D00002600F1 /* UIColor+Extension.swift in Sources */,
@@ -562,6 +580,7 @@
 				58368F122BD8B7D5009E008C /* HomeSearchBarView.swift in Sources */,
 				58BDFBA22BB2B8F5006AC994 /* SignUpViewController.swift in Sources */,
 				58BAC8B02BCCF59800CDEB1F /* NavigationActionButton.swift in Sources */,
+				586F03162BE0FD9A008660A0 /* PlaceSearchViewController+UICollectionView.swift in Sources */,
 				58DE93062BDF79C600C97575 /* PlacesSearchService.swift in Sources */,
 				584FA4222BA84254002600F1 /* BasicButton.swift in Sources */,
 				58DE930D2BDF94B600C97575 /* PlaceModel.swift in Sources */,
@@ -580,6 +599,7 @@
 				58DE93092BDF850B00C97575 /* PlaceSearchCollectionViewCell.swift in Sources */,
 				58DE930F2BDFA23200C97575 /* UIView+Extension.swift in Sources */,
 				58368EFE2BD75E9C009E008C /* FirebaseAuth+Extension.swift in Sources */,
+				586F03142BE0FCB5008660A0 /* PlaceSearchViewController+SearchBar.swift in Sources */,
 				58BDFBD12BBE5B53006AC994 /* HomeViewController.swift in Sources */,
 				58BDFBA42BB2E536006AC994 /* SignUpView.swift in Sources */,
 				584FA4302BABC0EE002600F1 /* LoginView.swift in Sources */,

--- a/GIL/GIL.xcodeproj/project.pbxproj
+++ b/GIL/GIL.xcodeproj/project.pbxproj
@@ -47,6 +47,7 @@
 		586F03122BE0FC55008660A0 /* PlaceSearchViewController+LocationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 586F03112BE0FC55008660A0 /* PlaceSearchViewController+LocationService.swift */; };
 		586F03142BE0FCB5008660A0 /* PlaceSearchViewController+SearchBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 586F03132BE0FCB5008660A0 /* PlaceSearchViewController+SearchBar.swift */; };
 		586F03162BE0FD9A008660A0 /* PlaceSearchViewController+UICollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 586F03152BE0FD9A008660A0 /* PlaceSearchViewController+UICollectionView.swift */; };
+		586F03182BE13696008660A0 /* HomeRecentSearchPlaceCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 586F03172BE13696008660A0 /* HomeRecentSearchPlaceCollectionViewCell.swift */; };
 		58A6808E2BDE7C02004E6706 /* LocationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58A6808D2BDE7C02004E6706 /* LocationService.swift */; };
 		58BAC8972BC52F8500CDEB1F /* UILabel+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58BAC8962BC52F8500CDEB1F /* UILabel+Extension.swift */; };
 		58BAC8992BC5399D00CDEB1F /* UITextField+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58BAC8982BC5399D00CDEB1F /* UITextField+Extension.swift */; };
@@ -124,6 +125,7 @@
 		586F03112BE0FC55008660A0 /* PlaceSearchViewController+LocationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PlaceSearchViewController+LocationService.swift"; sourceTree = "<group>"; };
 		586F03132BE0FCB5008660A0 /* PlaceSearchViewController+SearchBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PlaceSearchViewController+SearchBar.swift"; sourceTree = "<group>"; };
 		586F03152BE0FD9A008660A0 /* PlaceSearchViewController+UICollectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PlaceSearchViewController+UICollectionView.swift"; sourceTree = "<group>"; };
+		586F03172BE13696008660A0 /* HomeRecentSearchPlaceCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeRecentSearchPlaceCollectionViewCell.swift; sourceTree = "<group>"; };
 		58A6808D2BDE7C02004E6706 /* LocationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationService.swift; sourceTree = "<group>"; };
 		58BAC8962BC52F8500CDEB1F /* UILabel+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UILabel+Extension.swift"; sourceTree = "<group>"; };
 		58BAC8982BC5399D00CDEB1F /* UITextField+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITextField+Extension.swift"; sourceTree = "<group>"; };
@@ -193,6 +195,7 @@
 			isa = PBXGroup;
 			children = (
 				58368F0C2BD828C6009E008C /* HomeSearchCollectionViewCell.swift */,
+				586F03172BE13696008660A0 /* HomeRecentSearchPlaceCollectionViewCell.swift */,
 			);
 			path = Cells;
 			sourceTree = "<group>";
@@ -626,6 +629,7 @@
 				586F030C2BE0C4A2008660A0 /* LanguageCode.swift in Sources */,
 				58BDFBCC2BBAA78F006AC994 /* String+Extension.swift in Sources */,
 				58BAC8992BC5399D00CDEB1F /* UITextField+Extension.swift in Sources */,
+				586F03182BE13696008660A0 /* HomeRecentSearchPlaceCollectionViewCell.swift in Sources */,
 				584FA44A2BB15D51002600F1 /* LoginViewModel.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/GIL/GIL.xcodeproj/project.pbxproj
+++ b/GIL/GIL.xcodeproj/project.pbxproj
@@ -9,6 +9,14 @@
 /* Begin PBXBuildFile section */
 		5806472A2BCD147A00FB7310 /* UIImage+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 580647292BCD147A00FB7310 /* UIImage+Extension.swift */; };
 		5810DE202BE1F78400180BFB /* MappinImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5810DE1F2BE1F78400180BFB /* MappinImageView.swift */; };
+		5810DE232BE1FD3900180BFB /* HomeViewController+CollectionViewSetup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5810DE222BE1FD3900180BFB /* HomeViewController+CollectionViewSetup.swift */; };
+		5810DE252BE1FE1300180BFB /* HomeViewController+DataSourceConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5810DE242BE1FE1300180BFB /* HomeViewController+DataSourceConfiguration.swift */; };
+		5810DE272BE1FF3A00180BFB /* HomeViewController+UIUpdates.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5810DE262BE1FF3A00180BFB /* HomeViewController+UIUpdates.swift */; };
+		5810DE2B2BE2001600180BFB /* PlaceSearchViewController+CollectionViewSetup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5810DE2A2BE2001600180BFB /* PlaceSearchViewController+CollectionViewSetup.swift */; };
+		5810DE2D2BE2006600180BFB /* PlaceSearchViewController+DataSourceConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5810DE2C2BE2006600180BFB /* PlaceSearchViewController+DataSourceConfiguration.swift */; };
+		5810DE2F2BE200AC00180BFB /* PlaceSearchViewController+BindigSetup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5810DE2E2BE200AC00180BFB /* PlaceSearchViewController+BindigSetup.swift */; };
+		5810DE312BE200F600180BFB /* PlaceSearchViewController+UIUpdates.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5810DE302BE200F600180BFB /* PlaceSearchViewController+UIUpdates.swift */; };
+		5810DE332BE2013D00180BFB /* PlaceSearchViewController+Actions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5810DE322BE2013D00180BFB /* PlaceSearchViewController+Actions.swift */; };
 		58368EFA2BD51957009E008C /* BasicLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58368EF92BD51957009E008C /* BasicLabel.swift */; };
 		58368EFC2BD536B8009E008C /* AlertService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58368EFB2BD536B8009E008C /* AlertService.swift */; };
 		58368EFE2BD75E9C009E008C /* FirebaseAuth+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58368EFD2BD75E9C009E008C /* FirebaseAuth+Extension.swift */; };
@@ -89,6 +97,14 @@
 /* Begin PBXFileReference section */
 		580647292BCD147A00FB7310 /* UIImage+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+Extension.swift"; sourceTree = "<group>"; };
 		5810DE1F2BE1F78400180BFB /* MappinImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MappinImageView.swift; sourceTree = "<group>"; };
+		5810DE222BE1FD3900180BFB /* HomeViewController+CollectionViewSetup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "HomeViewController+CollectionViewSetup.swift"; sourceTree = "<group>"; };
+		5810DE242BE1FE1300180BFB /* HomeViewController+DataSourceConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "HomeViewController+DataSourceConfiguration.swift"; sourceTree = "<group>"; };
+		5810DE262BE1FF3A00180BFB /* HomeViewController+UIUpdates.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "HomeViewController+UIUpdates.swift"; sourceTree = "<group>"; };
+		5810DE2A2BE2001600180BFB /* PlaceSearchViewController+CollectionViewSetup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PlaceSearchViewController+CollectionViewSetup.swift"; sourceTree = "<group>"; };
+		5810DE2C2BE2006600180BFB /* PlaceSearchViewController+DataSourceConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PlaceSearchViewController+DataSourceConfiguration.swift"; sourceTree = "<group>"; };
+		5810DE2E2BE200AC00180BFB /* PlaceSearchViewController+BindigSetup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PlaceSearchViewController+BindigSetup.swift"; sourceTree = "<group>"; };
+		5810DE302BE200F600180BFB /* PlaceSearchViewController+UIUpdates.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PlaceSearchViewController+UIUpdates.swift"; sourceTree = "<group>"; };
+		5810DE322BE2013D00180BFB /* PlaceSearchViewController+Actions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PlaceSearchViewController+Actions.swift"; sourceTree = "<group>"; };
 		58368EF92BD51957009E008C /* BasicLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BasicLabel.swift; sourceTree = "<group>"; };
 		58368EFB2BD536B8009E008C /* AlertService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertService.swift; sourceTree = "<group>"; };
 		58368EFD2BD75E9C009E008C /* FirebaseAuth+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FirebaseAuth+Extension.swift"; sourceTree = "<group>"; };
@@ -182,6 +198,28 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		5810DE212BE1FD0700180BFB /* Extension */ = {
+			isa = PBXGroup;
+			children = (
+				5810DE222BE1FD3900180BFB /* HomeViewController+CollectionViewSetup.swift */,
+				5810DE242BE1FE1300180BFB /* HomeViewController+DataSourceConfiguration.swift */,
+				5810DE262BE1FF3A00180BFB /* HomeViewController+UIUpdates.swift */,
+			);
+			path = Extension;
+			sourceTree = "<group>";
+		};
+		5810DE292BE1FFEC00180BFB /* Extension */ = {
+			isa = PBXGroup;
+			children = (
+				5810DE2A2BE2001600180BFB /* PlaceSearchViewController+CollectionViewSetup.swift */,
+				5810DE2C2BE2006600180BFB /* PlaceSearchViewController+DataSourceConfiguration.swift */,
+				5810DE2E2BE200AC00180BFB /* PlaceSearchViewController+BindigSetup.swift */,
+				5810DE302BE200F600180BFB /* PlaceSearchViewController+UIUpdates.swift */,
+				5810DE322BE2013D00180BFB /* PlaceSearchViewController+Actions.swift */,
+			);
+			path = Extension;
+			sourceTree = "<group>";
+		};
 		58368EFF2BD76162009E008C /* Enum */ = {
 			isa = PBXGroup;
 			children = (
@@ -214,6 +252,7 @@
 			children = (
 				58368F1B2BDE4650009E008C /* Views */,
 				58DE93072BDF841300C97575 /* Cells */,
+				5810DE292BE1FFEC00180BFB /* Extension */,
 				586F03102BE0FC24008660A0 /* Delegate */,
 				58368F152BDE41FC009E008C /* PlaceSearchViewController.swift */,
 				58368F172BDE4243009E008C /* PlaceSearchViewModel.swift */,
@@ -392,6 +431,7 @@
 			children = (
 				58368F132BD8C1C2009E008C /* Views */,
 				58368F0E2BD828CA009E008C /* Cells */,
+				5810DE212BE1FD0700180BFB /* Extension */,
 				58BDFBD02BBE5B53006AC994 /* HomeViewController.swift */,
 				58368F022BD80472009E008C /* HomeInteractor.swift */,
 				58368F042BD8047E009E008C /* HomePresenter.swift */,
@@ -585,6 +625,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				5810DE232BE1FD3900180BFB /* HomeViewController+CollectionViewSetup.swift in Sources */,
 				586F030F2BE0D050008660A0 /* PlaceData.swift in Sources */,
 				58368EFC2BD536B8009E008C /* AlertService.swift in Sources */,
 				584FA41B2BA7F606002600F1 /* LoginViewController.swift in Sources */,
@@ -613,15 +654,20 @@
 				58BAC8972BC52F8500CDEB1F /* UILabel+Extension.swift in Sources */,
 				58368EFA2BD51957009E008C /* BasicLabel.swift in Sources */,
 				584FA3E72BA41484002600F1 /* AppDelegate.swift in Sources */,
+				5810DE2D2BE2006600180BFB /* PlaceSearchViewController+DataSourceConfiguration.swift in Sources */,
 				58368F1D2BDE4AD2009E008C /* PlaceSearchNavigationBar.swift in Sources */,
 				584FA41E2BA82886002600F1 /* BasicTextField.swift in Sources */,
+				5810DE332BE2013D00180BFB /* PlaceSearchViewController+Actions.swift in Sources */,
 				58DE93092BDF850B00C97575 /* PlaceSearchCollectionViewCell.swift in Sources */,
 				58DE930F2BDFA23200C97575 /* UIView+Extension.swift in Sources */,
+				5810DE252BE1FE1300180BFB /* HomeViewController+DataSourceConfiguration.swift in Sources */,
 				58368EFE2BD75E9C009E008C /* FirebaseAuth+Extension.swift in Sources */,
 				586F03142BE0FCB5008660A0 /* PlaceSearchViewController+SearchBar.swift in Sources */,
 				58BDFBD12BBE5B53006AC994 /* HomeViewController.swift in Sources */,
 				58BDFBA42BB2E536006AC994 /* SignUpView.swift in Sources */,
 				584FA4302BABC0EE002600F1 /* LoginView.swift in Sources */,
+				5810DE2B2BE2001600180BFB /* PlaceSearchViewController+CollectionViewSetup.swift in Sources */,
+				5810DE2F2BE200AC00180BFB /* PlaceSearchViewController+BindigSetup.swift in Sources */,
 				584FA3E92BA41484002600F1 /* SceneDelegate.swift in Sources */,
 				58368F0D2BD828C6009E008C /* HomeSearchCollectionViewCell.swift in Sources */,
 				58368F0B2BD81C6C009E008C /* UIViewController+NavigationBarHideable.swift in Sources */,
@@ -629,8 +675,10 @@
 				586F030C2BE0C4A2008660A0 /* LanguageCode.swift in Sources */,
 				58BDFBCC2BBAA78F006AC994 /* String+Extension.swift in Sources */,
 				58BAC8992BC5399D00CDEB1F /* UITextField+Extension.swift in Sources */,
+				5810DE312BE200F600180BFB /* PlaceSearchViewController+UIUpdates.swift in Sources */,
 				586F03182BE13696008660A0 /* HomeRecentSearchPlaceCollectionViewCell.swift in Sources */,
 				584FA44A2BB15D51002600F1 /* LoginViewModel.swift in Sources */,
+				5810DE272BE1FF3A00180BFB /* HomeViewController+UIUpdates.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/GIL/GIL.xcodeproj/project.pbxproj
+++ b/GIL/GIL.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		5810DE2F2BE200AC00180BFB /* PlaceSearchViewController+BindigSetup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5810DE2E2BE200AC00180BFB /* PlaceSearchViewController+BindigSetup.swift */; };
 		5810DE312BE200F600180BFB /* PlaceSearchViewController+UIUpdates.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5810DE302BE200F600180BFB /* PlaceSearchViewController+UIUpdates.swift */; };
 		5810DE332BE2013D00180BFB /* PlaceSearchViewController+Actions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5810DE322BE2013D00180BFB /* PlaceSearchViewController+Actions.swift */; };
+		583210B82BE69EB700D9DCA1 /* CollectionViewCellProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 583210B72BE69EB700D9DCA1 /* CollectionViewCellProtocol.swift */; };
 		58368EFA2BD51957009E008C /* BasicLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58368EF92BD51957009E008C /* BasicLabel.swift */; };
 		58368EFC2BD536B8009E008C /* AlertService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58368EFB2BD536B8009E008C /* AlertService.swift */; };
 		58368EFE2BD75E9C009E008C /* FirebaseAuth+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58368EFD2BD75E9C009E008C /* FirebaseAuth+Extension.swift */; };
@@ -105,6 +106,7 @@
 		5810DE2E2BE200AC00180BFB /* PlaceSearchViewController+BindigSetup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PlaceSearchViewController+BindigSetup.swift"; sourceTree = "<group>"; };
 		5810DE302BE200F600180BFB /* PlaceSearchViewController+UIUpdates.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PlaceSearchViewController+UIUpdates.swift"; sourceTree = "<group>"; };
 		5810DE322BE2013D00180BFB /* PlaceSearchViewController+Actions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PlaceSearchViewController+Actions.swift"; sourceTree = "<group>"; };
+		583210B72BE69EB700D9DCA1 /* CollectionViewCellProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectionViewCellProtocol.swift; sourceTree = "<group>"; };
 		58368EF92BD51957009E008C /* BasicLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BasicLabel.swift; sourceTree = "<group>"; };
 		58368EFB2BD536B8009E008C /* AlertService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertService.swift; sourceTree = "<group>"; };
 		58368EFD2BD75E9C009E008C /* FirebaseAuth+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FirebaseAuth+Extension.swift"; sourceTree = "<group>"; };
@@ -220,6 +222,14 @@
 			path = Extension;
 			sourceTree = "<group>";
 		};
+		583210B62BE69EA800D9DCA1 /* Protocol */ = {
+			isa = PBXGroup;
+			children = (
+				583210B72BE69EB700D9DCA1 /* CollectionViewCellProtocol.swift */,
+			);
+			path = Protocol;
+			sourceTree = "<group>";
+		};
 		58368EFF2BD76162009E008C /* Enum */ = {
 			isa = PBXGroup;
 			children = (
@@ -299,6 +309,7 @@
 				586F030D2BE0D03D008660A0 /* SwiftData */,
 				584FA4202BA82D26002600F1 /* Component */,
 				584FA4262BA84CF5002600F1 /* Extension */,
+				583210B62BE69EA800D9DCA1 /* Protocol */,
 				58368EFF2BD76162009E008C /* Enum */,
 				58BDFBC62BBA8C21006AC994 /* Utilities */,
 				584FA3E62BA41484002600F1 /* AppDelegate.swift */,
@@ -677,6 +688,7 @@
 				58BAC8992BC5399D00CDEB1F /* UITextField+Extension.swift in Sources */,
 				5810DE312BE200F600180BFB /* PlaceSearchViewController+UIUpdates.swift in Sources */,
 				586F03182BE13696008660A0 /* HomeRecentSearchPlaceCollectionViewCell.swift in Sources */,
+				583210B82BE69EB700D9DCA1 /* CollectionViewCellProtocol.swift in Sources */,
 				584FA44A2BB15D51002600F1 /* LoginViewModel.swift in Sources */,
 				5810DE272BE1FF3A00180BFB /* HomeViewController+UIUpdates.swift in Sources */,
 			);

--- a/GIL/GIL/Component/MappinImageView.swift
+++ b/GIL/GIL/Component/MappinImageView.swift
@@ -1,0 +1,47 @@
+//
+//  MappinImageView.swift
+//  GIL
+//
+//  Created by 송우진 on 5/1/24.
+//
+
+import UIKit
+
+final class MappinImageView: UIImageView {
+    enum IconType {
+        case filled
+        case outline
+        
+        var imageName: String {
+            switch self {
+            case .filled: return "mappin.and.ellipse.circle.fill"
+            case .outline: return "mappin.and.ellipse"
+            }
+        }
+    }
+    
+    // MARK: - Initialization
+    init(
+        iconType: IconType,
+        tintColor: UIColor = .mainGreen
+    ) {
+        super.init(frame: .zero)
+        setupIcon(iconType: iconType, tintColor: tintColor)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+// MARK: - Setup UI
+extension MappinImageView {
+    func setupIcon(
+        iconType: IconType,
+        tintColor color: UIColor
+    ) {
+        contentMode = .scaleAspectFit
+        tintColor = color
+        image = UIImage(systemName: iconType.imageName)
+    }
+}

--- a/GIL/GIL/Model/PlaceModel.swift
+++ b/GIL/GIL/Model/PlaceModel.swift
@@ -7,53 +7,19 @@
 
 import MapKit
 
-struct Place: Hashable {
-    let name: String?
-    let coordinate: CLLocationCoordinate2D
-    let address: String?
-    let phoneNumber: String?
-    let url: URL?
-    let category: String?
-    let distance: Double?
-}
-
-// MARK: - Initialization
-extension Place {
+struct Place: Hashable, Codable {
+    let name: String
+    let address: String
+    let category: String
+    let distance: Double
+    
     init(
-        from mapItem: MKMapItem,
-        distance: Double? = nil
+        mapItem: MKMapItem,
+        distance: Double = 0.0
     ) {
-        self.name = mapItem.name
-        self.coordinate = mapItem.placemark.coordinate
-        self.address = mapItem.placemark.title
-        self.phoneNumber = mapItem.phoneNumber
-        self.url = mapItem.url
-        self.category = mapItem.pointOfInterestCategory?.rawValue
+        self.name = mapItem.name ?? ""
+        self.address = mapItem.placemark.title ?? ""
+        self.category = mapItem.pointOfInterestCategory?.rawValue ?? ""
         self.distance = distance
-    }
-}
-
-// MARK: - Hashable
-extension Place {
-    func hash(into hasher: inout Hasher) {
-        hasher.combine(name)
-        hasher.combine(coordinate.latitude)
-        hasher.combine(coordinate.longitude)
-        hasher.combine(address)
-        hasher.combine(phoneNumber)
-        hasher.combine(url)
-        hasher.combine(category)
-        hasher.combine(distance)
-    }
-        
-    static func == (lhs: Place, rhs: Place) -> Bool {
-        lhs.name == rhs.name &&
-        lhs.coordinate.latitude == rhs.coordinate.latitude &&
-        lhs.coordinate.longitude == rhs.coordinate.longitude &&
-        lhs.address == rhs.address &&
-        lhs.phoneNumber == rhs.phoneNumber &&
-        lhs.url == rhs.url &&
-        lhs.category == rhs.category &&
-        lhs.distance == rhs.distance
     }
 }

--- a/GIL/GIL/Protocol/CollectionViewCellProtocol.swift
+++ b/GIL/GIL/Protocol/CollectionViewCellProtocol.swift
@@ -1,0 +1,12 @@
+//
+//  CollectionViewCellProtocol.swift
+//  GIL
+//
+//  Created by 송우진 on 5/5/24.
+//
+
+import Foundation
+
+protocol CollectionViewCellProtocol {
+    static var reuseIdentifier: String { get }
+}

--- a/GIL/GIL/SceneDelegate.swift
+++ b/GIL/GIL/SceneDelegate.swift
@@ -37,20 +37,9 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     }
     
     @objc private func updateRootViewControllerBasedOnAuthenticationStatus() {
-        let presenter = HomePresenter()
-        let interactor = HomeInteractor()
-        interactor.presenter = presenter
-        
-        let homeViewController = HomeViewController(interactor: interactor)
-        presenter.viewController = homeViewController
-        
+        let homeViewController = HomeViewController()
         let loginViewController = LoginViewController(viewModel: LoginViewModel())
-        
-        window?.rootViewController = (Auth.auth().currentUser != nil) ?
-        UINavigationController(rootViewController: homeViewController) :
-            UINavigationController(rootViewController: loginViewController)
-        
-        
+        window?.rootViewController = (Auth.auth().currentUser != nil) ? UINavigationController(rootViewController: homeViewController) : UINavigationController(rootViewController: loginViewController)
     }
 }
 

--- a/GIL/GIL/Screen/Home/Cells/HomeRecentSearchPlaceCollectionViewCell.swift
+++ b/GIL/GIL/Screen/Home/Cells/HomeRecentSearchPlaceCollectionViewCell.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-class HomeRecentSearchPlaceCollectionViewCell: UICollectionViewCell {
+class HomeRecentSearchPlaceCollectionViewCell: UICollectionViewCell, CollectionViewCellProtocol {
     static let reuseIdentifier = "HomeRecentSearchPlaceCell"
     private var buttons: [UIButton] = []
     

--- a/GIL/GIL/Screen/Home/Cells/HomeRecentSearchPlaceCollectionViewCell.swift
+++ b/GIL/GIL/Screen/Home/Cells/HomeRecentSearchPlaceCollectionViewCell.swift
@@ -1,0 +1,90 @@
+//
+//  HomeRecentSearchPlaceCollectionViewCell.swift
+//  GIL
+//
+//  Created by 송우진 on 4/30/24.
+//
+
+import UIKit
+
+class HomeRecentSearchPlaceCollectionViewCell: UICollectionViewCell {
+    static let reuseIdentifier = "HomeRecentSearchPlaceCell"
+    private var buttons: [UIButton] = []
+    
+}
+
+// MARK: - Configure Cell
+extension HomeRecentSearchPlaceCollectionViewCell {
+    func configure(with places: [PlaceData]) {
+        cleanupButtons()
+        configureButtons(with: places)
+    }
+    
+    private func cleanupButtons() {
+        buttons.forEach { $0.removeFromSuperview() }
+        buttons.removeAll()
+    }
+    
+    private func configureButtons(with places: [PlaceData]) {
+        var previousButton: UIButton? = nil
+        for place in places {
+            let button = createButton(for: place)
+            buttons.append(button)
+            contentView.addSubview(button)
+            button.translatesAutoresizingMaskIntoConstraints = false
+            
+            NSLayoutConstraint.activate([
+                button.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 16),
+                button.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -16),
+                button.topAnchor.constraint(equalTo: previousButton?.bottomAnchor ?? contentView.topAnchor, constant: 10)
+            ])
+            previousButton = button
+            
+            button.layoutIfNeeded()
+            button.addBorder(at: .bottom, color: .lightGrayBorder)
+        }
+        if let lastButton = buttons.last {
+            lastButton.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -10).isActive = true
+        }
+    }
+}
+
+
+// MARK: - Button Creation and Layout
+extension HomeRecentSearchPlaceCollectionViewCell {
+    private func createButton(for place: PlaceData) -> UIButton {
+        let button = UIButton()
+        button.backgroundColor = .systemBackground
+        
+        let iconImageView = MappinImageView(iconType: .filled)
+        let nameLabel = BasicLabel(text: place.place.name, fontSize: 15, fontWeight: .bold)
+        let addressLabel = BasicLabel(text: place.place.address, fontSize: 13, fontWeight: .medium)
+        
+        [iconImageView, nameLabel, addressLabel].forEach({
+            button.addSubview($0)
+            $0.translatesAutoresizingMaskIntoConstraints = false
+        })
+        
+        setupButtonLayout(button: button, icon: iconImageView, name: nameLabel, address: addressLabel)
+        
+        return button
+    }
+    
+    private func setupButtonLayout(button: UIButton, icon: UIImageView, name: UILabel, address: UILabel) {
+        NSLayoutConstraint.activate([
+            icon.leadingAnchor.constraint(equalTo: button.leadingAnchor, constant: 10),
+            icon.centerYAnchor.constraint(equalTo: button.centerYAnchor),
+            icon.widthAnchor.constraint(equalToConstant: 30),
+            icon.heightAnchor.constraint(equalToConstant: 30),
+            
+            name.leadingAnchor.constraint(equalTo: icon.trailingAnchor, constant: 10),
+            name.trailingAnchor.constraint(equalTo: button.trailingAnchor, constant: -10),
+            name.topAnchor.constraint(equalTo: button.topAnchor, constant: 10),
+            
+            address.leadingAnchor.constraint(equalTo: name.leadingAnchor),
+            address.trailingAnchor.constraint(equalTo: name.trailingAnchor),
+            address.topAnchor.constraint(equalTo: name.bottomAnchor, constant: 5),
+            address.bottomAnchor.constraint(equalTo: button.bottomAnchor, constant: -10)
+        ])
+    }
+}

--- a/GIL/GIL/Screen/Home/Cells/HomeSearchCollectionViewCell.swift
+++ b/GIL/GIL/Screen/Home/Cells/HomeSearchCollectionViewCell.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-class HomeSearchCollectionViewCell: UICollectionViewCell {
+class HomeSearchCollectionViewCell: UICollectionViewCell, CollectionViewCellProtocol {
     static let reuseIdentifier = "HomeSearchCell"
     let searchBarView = HomeSearchBarView()
     var onSearchBarTapped: (() -> Void)?

--- a/GIL/GIL/Screen/Home/Extension/HomeViewController+CollectionViewSetup.swift
+++ b/GIL/GIL/Screen/Home/Extension/HomeViewController+CollectionViewSetup.swift
@@ -1,0 +1,39 @@
+//
+//  HomeViewController+CollectionViewSetup.swift
+//  GIL
+//
+//  Created by 송우진 on 5/1/24.
+//
+
+import UIKit
+
+extension HomeViewController {
+    func setupCollectionView() {
+        homeView.mainCollectionView.collectionViewLayout = createLayout()
+    }
+
+    func createLayout() -> UICollectionViewLayout {
+        return UICollectionViewCompositionalLayout { sectionIndex, layoutEnvironment in
+            let section = Section.allCases[sectionIndex]
+            switch section {
+            case .main: return self.createMainSection()
+            }
+        }
+    }
+
+    private func createMainSection() -> NSCollectionLayoutSection {
+        let searchItemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .estimated(80))
+        let searchItem = NSCollectionLayoutItem(layoutSize: searchItemSize)
+        
+        let recentSearchItemHeight = CGFloat(50 * recentSearchCount)
+        let recentSearchItemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .estimated(recentSearchItemHeight))
+        let recentSearchItem = NSCollectionLayoutItem(layoutSize: recentSearchItemSize)
+        
+        let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .estimated(230))
+        let group = NSCollectionLayoutGroup.vertical(layoutSize: groupSize, subitems: [searchItem, recentSearchItem])
+        
+        let section = NSCollectionLayoutSection(group: group)
+        section.interGroupSpacing = 10
+        return section
+    }
+}

--- a/GIL/GIL/Screen/Home/Extension/HomeViewController+DataSourceConfiguration.swift
+++ b/GIL/GIL/Screen/Home/Extension/HomeViewController+DataSourceConfiguration.swift
@@ -1,0 +1,50 @@
+//
+//  HomeViewController+DataSourceConfiguration.swift
+//  GIL
+//
+//  Created by 송우진 on 5/1/24.
+//
+
+import UIKit
+
+extension HomeViewController {
+    func configureDataSource() {
+        dataSource = UICollectionViewDiffableDataSource<Section, Item>(collectionView: homeView.mainCollectionView) { (collectionView, indexPath, item) -> UICollectionViewCell? in
+            switch item {
+            case .search: 
+                return self.configureSearchCell(for: collectionView, at: indexPath)
+            case let .recentSearchPlace(placeData):
+                return self.configureRecentSearchPlaceCell(for: collectionView, at: indexPath, with: placeData)
+            }
+        }
+
+        var snapshot = NSDiffableDataSourceSnapshot<Section, Item>()
+        snapshot.appendSections([.main])
+        snapshot.appendItems([.search], toSection: .main)
+        dataSource.apply(snapshot, animatingDifferences: false)
+    }
+    
+    private func configureSearchCell(
+        for collectionView: UICollectionView,
+        at indexPath: IndexPath
+    ) -> UICollectionViewCell {
+        guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: HomeSearchCollectionViewCell.reuseIdentifier, for: indexPath) as? HomeSearchCollectionViewCell else { return UICollectionViewCell() }
+        
+        cell.onSearchBarTapped = { [weak self] in
+            guard let self else { return }
+            self.interactor.performSearch()
+        }
+        return cell
+    }
+
+    private func configureRecentSearchPlaceCell(
+        for collectionView: UICollectionView,
+        at indexPath: IndexPath,
+        with data: [PlaceData]
+    ) -> UICollectionViewCell {
+        guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: HomeRecentSearchPlaceCollectionViewCell.reuseIdentifier, for: indexPath) as? HomeRecentSearchPlaceCollectionViewCell else { return UICollectionViewCell() }
+        
+        cell.configure(with: data)
+        return cell
+    }
+}

--- a/GIL/GIL/Screen/Home/Extension/HomeViewController+UIUpdates.swift
+++ b/GIL/GIL/Screen/Home/Extension/HomeViewController+UIUpdates.swift
@@ -1,0 +1,30 @@
+//
+//  HomeViewController+UIUpdates.swift
+//  GIL
+//
+//  Created by 송우진 on 5/1/24.
+//
+
+import Foundation
+
+extension HomeViewController {
+    func updateSnapshot(with data: [PlaceData]) {
+        recentSearchCount = data.count
+        
+        var snapshot = dataSource.snapshot()
+        snapshot.deleteItems(snapshot.itemIdentifiers(inSection: .main).filter {
+            if case .recentSearchPlace = $0 { return true }
+            return false
+        })
+        let newItems = [Item.recentSearchPlace(data)]
+        snapshot.appendItems(newItems, toSection: .main)
+        dataSource.apply(snapshot, animatingDifferences: true)
+        
+        resetLayout()
+    }
+    
+    private func resetLayout() {
+        let newLayout = createLayout()
+        homeView.mainCollectionView.setCollectionViewLayout(newLayout, animated: false)
+    }
+}

--- a/GIL/GIL/Screen/Home/HomeInteractor.swift
+++ b/GIL/GIL/Screen/Home/HomeInteractor.swift
@@ -16,14 +16,14 @@ protocol HomeBusinessLogic {
 final class HomeInteractor: HomeBusinessLogic {
     var presenter: HomePresentationLogic?
     private var placeContainer: ModelContainer?
-
+    
     init() {
         placeContainer = try? ModelContainer(for: PlaceData.self)
     }
     
     @MainActor
     func fetchPlaceData() {
-        let descriptor = FetchDescriptor<PlaceData>(sortBy: [SortDescriptor(\.saveDate)])
+        let descriptor = FetchDescriptor<PlaceData>(sortBy: [SortDescriptor(\.saveDate, order: .reverse)])
         let places = (try? placeContainer?.mainContext.fetch(descriptor)) ?? []
         presenter?.presentFetchedData(places)
     }

--- a/GIL/GIL/Screen/Home/HomeInteractor.swift
+++ b/GIL/GIL/Screen/Home/HomeInteractor.swift
@@ -6,13 +6,27 @@
 //
 
 import Foundation
+import SwiftData
 
 protocol HomeBusinessLogic {
     func performSearch()
+    func fetchPlaceData()
 }
 
 final class HomeInteractor: HomeBusinessLogic {
     var presenter: HomePresentationLogic?
+    private var placeContainer: ModelContainer?
+
+    init() {
+        placeContainer = try? ModelContainer(for: PlaceData.self)
+    }
+    
+    @MainActor
+    func fetchPlaceData() {
+        let descriptor = FetchDescriptor<PlaceData>(sortBy: [SortDescriptor(\.saveDate)])
+        let places = (try? placeContainer?.mainContext.fetch(descriptor)) ?? []
+        presenter?.presentFetchedData(places)
+    }
     
     func performSearch() {
         presenter?.presentSearchScreen()

--- a/GIL/GIL/Screen/Home/HomePresenter.swift
+++ b/GIL/GIL/Screen/Home/HomePresenter.swift
@@ -8,10 +8,16 @@ import UIKit
 
 protocol HomePresentationLogic {
     func presentSearchScreen()
+    func presentFetchedData(_ data: [PlaceData])
 }
 
 final class HomePresenter: HomePresentationLogic {
     weak var viewController: HomeViewController?
+    
+    func presentFetchedData(_ data: [PlaceData]) {
+        let recentPlace = Array(data.prefix(min(3, data.count)))
+        viewController?.displayFetchedData(recentPlace)
+    }
     
     func presentSearchScreen() {
         viewController?.displaySearchScreen()

--- a/GIL/GIL/Screen/Home/HomeViewController.swift
+++ b/GIL/GIL/Screen/Home/HomeViewController.swift
@@ -29,9 +29,15 @@ final class HomeViewController: BaseViewController, NavigationBarHideable {
     var recentSearchCount = 0 // 최근 검색 개수를 추적하는 변수
     
     // MARK: - Initialization
-    init(interactor: HomeBusinessLogic) {
+    init() {
+        let presenter = HomePresenter()
+        let interactor = HomeInteractor()
+        interactor.presenter = presenter
         self.interactor = interactor
+        
         super.init(nibName: nil, bundle: nil)
+        
+        presenter.viewController = self
     }
     
     required init?(coder: NSCoder) {

--- a/GIL/GIL/Screen/Home/HomeViewController.swift
+++ b/GIL/GIL/Screen/Home/HomeViewController.swift
@@ -9,6 +9,7 @@ import UIKit
 
 protocol HomeDisplayLogic {
     func displaySearchScreen()
+    func displayFetchedData(_ data: [PlaceData])
 }
 
 final class HomeViewController: BaseViewController, NavigationBarHideable {
@@ -50,6 +51,7 @@ final class HomeViewController: BaseViewController, NavigationBarHideable {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         hideNavigationBar(animated: false)
+        interactor.fetchPlaceData()
     }
     
     override func viewWillDisappear(_ animated: Bool) {
@@ -60,6 +62,15 @@ final class HomeViewController: BaseViewController, NavigationBarHideable {
 
 // MARK: - HomeDisplayLogic
 extension HomeViewController: HomeDisplayLogic {
+    func displayFetchedData(_ data: [PlaceData]) {
+        data.forEach {
+            Log.info("Place", [
+                $0.saveDate,
+                $0.place
+            ])
+        }
+    }
+    
     func displaySearchScreen() {
         let searchDetailVC = PlaceSearchViewController(viewModel: PlaceSearchViewModel())
         navigationController?.pushViewController(searchDetailVC, animated: true)

--- a/GIL/GIL/Screen/Home/Views/HomeView.swift
+++ b/GIL/GIL/Screen/Home/Views/HomeView.swift
@@ -14,8 +14,8 @@ final class HomeView: UIView {
         layout.scrollDirection = .vertical
         let collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
         collectionView.backgroundColor = .systemBackground
-        collectionView.register(UICollectionViewCell.self, forCellWithReuseIdentifier: "NormalCell")
         collectionView.register(HomeSearchCollectionViewCell.self, forCellWithReuseIdentifier: HomeSearchCollectionViewCell.reuseIdentifier)
+        collectionView.register(HomeRecentSearchPlaceCollectionViewCell.self, forCellWithReuseIdentifier: HomeRecentSearchPlaceCollectionViewCell.reuseIdentifier)
         return collectionView
     }()
     

--- a/GIL/GIL/Screen/PlaceSearch/Cells/PlaceSearchCollectionViewCell.swift
+++ b/GIL/GIL/Screen/PlaceSearch/Cells/PlaceSearchCollectionViewCell.swift
@@ -7,8 +7,8 @@
 
 import UIKit
 
-class PlaceSearchCollectionViewCell: UICollectionViewCell {
-    static let reuseIdentifier = "PlaceSearchCell"
+class PlaceSearchCollectionViewCell: UICollectionViewCell, CollectionViewCellProtocol {
+    static let reuseIdentifier: String = "PlaceSearchCell"
     private let mappinIcon = MappinImageView(iconType: .outline)
     private let stackView: UIStackView = {
         let stack = UIStackView()

--- a/GIL/GIL/Screen/PlaceSearch/Cells/PlaceSearchCollectionViewCell.swift
+++ b/GIL/GIL/Screen/PlaceSearch/Cells/PlaceSearchCollectionViewCell.swift
@@ -9,13 +9,7 @@ import UIKit
 
 class PlaceSearchCollectionViewCell: UICollectionViewCell {
     static let reuseIdentifier = "PlaceSearchCell"
-    private let mappinIcon: UIImageView = {
-        let imageView = UIImageView()
-        imageView.image = UIImage(systemName: "mappin.and.ellipse")
-        imageView.contentMode = .scaleAspectFit
-        imageView.tintColor = .mainGreen
-        return imageView
-    }()
+    private let mappinIcon = MappinImageView(iconType: .outline)
     private let stackView: UIStackView = {
         let stack = UIStackView()
         stack.axis = .vertical

--- a/GIL/GIL/Screen/PlaceSearch/Cells/PlaceSearchCollectionViewCell.swift
+++ b/GIL/GIL/Screen/PlaceSearch/Cells/PlaceSearchCollectionViewCell.swift
@@ -78,9 +78,9 @@ extension PlaceSearchCollectionViewCell {
     func updateContent(with item: Place) {
         nameLabel.text = item.name
         
-        if let distance = item.distance {
-            let formattedDistance = formatDistance(distance)
-            addressLabel.text = "\(formattedDistance) · \(item.address ?? "")"
+        if item.distance > 0 {
+            let formattedDistance = formatDistance(item.distance)
+            addressLabel.text = "\(formattedDistance) · \(item.address)"
         } else {
             addressLabel.text = item.address
         }

--- a/GIL/GIL/Screen/PlaceSearch/Delegate/PlaceSearchViewController+LocationService.swift
+++ b/GIL/GIL/Screen/PlaceSearch/Delegate/PlaceSearchViewController+LocationService.swift
@@ -1,0 +1,19 @@
+//
+//  PlaceSearchViewController+LocationService.swift
+//  GIL
+//
+//  Created by 송우진 on 4/30/24.
+//
+
+import Foundation
+
+extension PlaceSearchViewController: LocationServiceDelegate {
+    func didFetchAddress(_ address: String) {
+        viewModel.locationService.stopUpdatingLocation()
+        placeSearchView.navigationBar.addressLabel.text = address
+    }
+    
+    func didFailWithError(_ error: Error) {
+        Log.error("LocationService Error: \(error.localizedDescription)", error)
+    }
+}

--- a/GIL/GIL/Screen/PlaceSearch/Delegate/PlaceSearchViewController+SearchBar.swift
+++ b/GIL/GIL/Screen/PlaceSearch/Delegate/PlaceSearchViewController+SearchBar.swift
@@ -1,0 +1,17 @@
+//
+//  PlaceSearchViewController+SearchBar.swift
+//  GIL
+//
+//  Created by 송우진 on 4/30/24.
+//
+
+import UIKit
+
+extension PlaceSearchViewController: UISearchBarDelegate {
+    func searchBar(
+        _ searchBar: UISearchBar,
+        textDidChange searchText: String
+    ) {
+        viewModel.searchPlace(searchText)
+    }
+}

--- a/GIL/GIL/Screen/PlaceSearch/Delegate/PlaceSearchViewController+UICollectionView.swift
+++ b/GIL/GIL/Screen/PlaceSearch/Delegate/PlaceSearchViewController+UICollectionView.swift
@@ -1,0 +1,18 @@
+//
+//  PlaceSearchViewController+UICollectionView.swift
+//  GIL
+//
+//  Created by 송우진 on 4/30/24.
+//
+
+import UIKit
+
+extension PlaceSearchViewController: UICollectionViewDelegate {
+    func collectionView(
+        _ collectionView: UICollectionView,
+        didSelectItemAt indexPath: IndexPath
+    ) {
+        let place = viewModel.mapItems[indexPath.row]
+        viewModel.saveData(data: place)
+    }
+}

--- a/GIL/GIL/Screen/PlaceSearch/Delegate/PlaceSearchViewController+UICollectionView.swift
+++ b/GIL/GIL/Screen/PlaceSearch/Delegate/PlaceSearchViewController+UICollectionView.swift
@@ -13,6 +13,6 @@ extension PlaceSearchViewController: UICollectionViewDelegate {
         didSelectItemAt indexPath: IndexPath
     ) {
         let place = viewModel.mapItems[indexPath.row]
-        viewModel.saveData(data: place)
+        viewModel.storePlace(place)
     }
 }

--- a/GIL/GIL/Screen/PlaceSearch/Extension/PlaceSearchViewController+Actions.swift
+++ b/GIL/GIL/Screen/PlaceSearch/Extension/PlaceSearchViewController+Actions.swift
@@ -1,0 +1,14 @@
+//
+//  PlaceSearchViewController+Actions.swift
+//  GIL
+//
+//  Created by 송우진 on 5/1/24.
+//
+
+import Foundation
+
+extension PlaceSearchViewController {
+    func backButtonTapped() {
+        navigationController?.popViewController(animated: true)
+    }
+}

--- a/GIL/GIL/Screen/PlaceSearch/Extension/PlaceSearchViewController+BindigSetup.swift
+++ b/GIL/GIL/Screen/PlaceSearch/Extension/PlaceSearchViewController+BindigSetup.swift
@@ -1,0 +1,45 @@
+//
+//  PlaceSearchViewController+BindigSetup.swift
+//  GIL
+//
+//  Created by 송우진 on 5/1/24.
+//
+
+import UIKit
+
+extension PlaceSearchViewController {
+    func setupBindings() {
+        bindButtons()
+        bindSearchBar()
+        bindCollectionView()
+        bindLocationService()
+        bindSearchMapItems()
+    }
+    
+    private func bindButtons() {
+        let backAction = UIAction { _ in self.backButtonTapped() }
+        placeSearchView.navigationBar.backButton.addAction(backAction, for: .touchUpInside)
+    }
+    
+    private func bindSearchBar() {
+        placeSearchView.navigationBar.searchBar.delegate = self
+    }
+    
+    private func bindCollectionView() {
+        placeSearchView.searchResultsCollectionView.delegate = self
+    }
+    
+    private func bindLocationService() {
+        viewModel.locationService.delegate = self
+    }
+    
+    private func bindSearchMapItems() {
+        viewModel.$mapItems
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] mapItems in
+                guard let self else { return }
+                self.applySnapshot(with: mapItems)
+            }
+            .store(in: &viewModel.cancellables)
+    }
+}

--- a/GIL/GIL/Screen/PlaceSearch/Extension/PlaceSearchViewController+CollectionViewSetup.swift
+++ b/GIL/GIL/Screen/PlaceSearch/Extension/PlaceSearchViewController+CollectionViewSetup.swift
@@ -1,0 +1,28 @@
+//
+//  PlaceSearchViewController+CollectionViewSetup.swift
+//  GIL
+//
+//  Created by 송우진 on 5/1/24.
+//
+
+import UIKit
+
+extension PlaceSearchViewController {
+    func setupCollectionView() {
+        placeSearchView.searchResultsCollectionView.collectionViewLayout = createLayout()
+    }
+    
+    private func createLayout() -> UICollectionViewLayout {
+        let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .estimated(70))
+        let item = NSCollectionLayoutItem(layoutSize: itemSize)
+
+        let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .estimated(70))
+        let group = NSCollectionLayoutGroup.vertical(layoutSize: groupSize, subitems: [item])
+
+        let section = NSCollectionLayoutSection(group: group)
+        section.interGroupSpacing = 5
+        section.contentInsets = NSDirectionalEdgeInsets(top: 10, leading: 16, bottom: 10, trailing: 16)
+
+        return UICollectionViewCompositionalLayout(section: section)
+    }
+}

--- a/GIL/GIL/Screen/PlaceSearch/Extension/PlaceSearchViewController+DataSourceConfiguration.swift
+++ b/GIL/GIL/Screen/PlaceSearch/Extension/PlaceSearchViewController+DataSourceConfiguration.swift
@@ -1,0 +1,35 @@
+//
+//  PlaceSearchViewController+DataSourceConfiguration.swift
+//  GIL
+//
+//  Created by 송우진 on 5/1/24.
+//
+
+import UIKit
+
+extension PlaceSearchViewController {
+    func configureDataSource() {
+        dataSource = UICollectionViewDiffableDataSource<Section, Place>(collectionView: placeSearchView.searchResultsCollectionView) { (collectionView, indexPath, place) -> UICollectionViewCell? in
+            self.configurePlaceSearcCell(for: collectionView, at: indexPath, item: place)
+        }
+        
+        var snapshot = NSDiffableDataSourceSnapshot<Section, Place>()
+        snapshot.appendSections([.main])
+        snapshot.appendItems([], toSection: .main)
+        dataSource.apply(snapshot, animatingDifferences: false)
+    }
+    
+    private func configurePlaceSearcCell(
+        for collectionView: UICollectionView,
+        at indexPath: IndexPath,
+        item: Place
+    ) -> UICollectionViewCell {
+        guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: PlaceSearchCollectionViewCell.reuseIdentifier, for: indexPath) as? PlaceSearchCollectionViewCell else {
+            return UICollectionViewCell()
+        }
+        
+        cell.updateContent(with: item)
+        
+        return cell
+    }
+}

--- a/GIL/GIL/Screen/PlaceSearch/Extension/PlaceSearchViewController+UIUpdates.swift
+++ b/GIL/GIL/Screen/PlaceSearch/Extension/PlaceSearchViewController+UIUpdates.swift
@@ -1,0 +1,17 @@
+//
+//  PlaceSearchViewController+UIUpdates.swift
+//  GIL
+//
+//  Created by 송우진 on 5/1/24.
+//
+
+import UIKit
+
+extension PlaceSearchViewController {
+    func applySnapshot(with items: [Place]) {
+        var snapshot = dataSource.snapshot()
+        snapshot.deleteItems(snapshot.itemIdentifiers(inSection: .main))
+        snapshot.appendItems(items, toSection: .main)
+        dataSource.apply(snapshot, animatingDifferences: true)
+    }
+}

--- a/GIL/GIL/Screen/PlaceSearch/PlaceSearchViewController.swift
+++ b/GIL/GIL/Screen/PlaceSearch/PlaceSearchViewController.swift
@@ -117,7 +117,7 @@ extension PlaceSearchViewController {
         let item = NSCollectionLayoutItem(layoutSize: itemSize)
 
         let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .estimated(70))
-        let group = NSCollectionLayoutGroup.horizontal(layoutSize: groupSize, subitems: [item])
+        let group = NSCollectionLayoutGroup.vertical(layoutSize: groupSize, subitems: [item])
 
         let section = NSCollectionLayoutSection(group: group)
         section.interGroupSpacing = 5

--- a/GIL/GIL/Screen/PlaceSearch/PlaceSearchViewController.swift
+++ b/GIL/GIL/Screen/PlaceSearch/PlaceSearchViewController.swift
@@ -16,7 +16,7 @@ final class PlaceSearchViewController: BaseViewController, NavigationBarHideable
     
     var viewModel: PlaceSearchViewModel
     var placeSearchView = PlaceSearchView()
-    private var dataSource: UICollectionViewDiffableDataSource<Section, Place>!
+    var dataSource: UICollectionViewDiffableDataSource<Section, Place>!
     
     // MARK: - Initialization
     init(viewModel: PlaceSearchViewModel) {
@@ -48,104 +48,5 @@ final class PlaceSearchViewController: BaseViewController, NavigationBarHideable
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
         showNavigationBar(animated: false)
-    }
-}
-
-// MARK: - Actions
-extension PlaceSearchViewController {
-    private func backButtonTapped() {
-        navigationController?.popViewController(animated: true)
-    }
-}
-
-// MARK: - UI Updates
-extension PlaceSearchViewController {
-    private func applySnapshot(with items: [Place]) {
-        var snapshot = NSDiffableDataSourceSnapshot<Section, Place>()
-        snapshot.appendSections([.main])
-        snapshot.appendItems(items, toSection: .main)
-        dataSource.apply(snapshot, animatingDifferences: true)
-    }
-}
-
-// MARK: - Binding
-extension PlaceSearchViewController {
-    private func setupBindings() {
-        bindButtons()
-        bindSearchBar()
-        bindCollectionView()
-        bindLocationService()
-        bindSearchMapItems()
-    }
-    
-    private func bindButtons() {
-        let backAction = UIAction { _ in self.backButtonTapped() }
-        placeSearchView.navigationBar.backButton.addAction(backAction, for: .touchUpInside)
-    }
-    
-    private func bindSearchBar() {
-        placeSearchView.navigationBar.searchBar.delegate = self
-    }
-    
-    private func bindCollectionView() {
-        placeSearchView.searchResultsCollectionView.delegate = self
-    }
-    
-    private func bindLocationService() {
-        viewModel.locationService.delegate = self
-    }
-    
-    private func bindSearchMapItems() {
-        viewModel.$mapItems
-            .receive(on: DispatchQueue.main)
-            .sink { [weak self] mapItems in
-                guard let self else { return }
-                self.applySnapshot(with: mapItems)
-            }
-            .store(in: &viewModel.cancellables)
-    }
-}
-
-// MARK: - Collection View Setup and Layout
-extension PlaceSearchViewController {
-    private func setupCollectionView() {
-        placeSearchView.searchResultsCollectionView.collectionViewLayout = createLayout()
-    }
-    
-    private func createLayout() -> UICollectionViewLayout {
-        let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .estimated(70))
-        let item = NSCollectionLayoutItem(layoutSize: itemSize)
-
-        let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .estimated(70))
-        let group = NSCollectionLayoutGroup.vertical(layoutSize: groupSize, subitems: [item])
-
-        let section = NSCollectionLayoutSection(group: group)
-        section.interGroupSpacing = 5
-        section.contentInsets = NSDirectionalEdgeInsets(top: 10, leading: 16, bottom: 10, trailing: 16)
-
-        return UICollectionViewCompositionalLayout(section: section)
-    }
-}
-
-// MARK: - Collection View Data Source Configuration
-extension PlaceSearchViewController {
-    private func configureDataSource() {
-        dataSource = UICollectionViewDiffableDataSource<Section, Place>(collectionView: placeSearchView.searchResultsCollectionView) { (collectionView, indexPath, place) -> UICollectionViewCell? in
-            self.configurePlaceSearcCell(for: collectionView, at: indexPath, item: place)
-        }
-    }
-    
-    private func configurePlaceSearcCell(
-        for collectionView: UICollectionView,
-        at indexPath: IndexPath,
-        item: Place
-    ) -> UICollectionViewCell {
-        guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: PlaceSearchCollectionViewCell.reuseIdentifier, for: indexPath) as? PlaceSearchCollectionViewCell else {
-            return UICollectionViewCell()
-        }
-        
-        cell.updateContent(with: item)
-        
-        return cell
     }
 }

--- a/GIL/GIL/Screen/PlaceSearch/PlaceSearchViewModel.swift
+++ b/GIL/GIL/Screen/PlaceSearch/PlaceSearchViewModel.swift
@@ -44,4 +44,15 @@ class PlaceSearchViewModel {
         let data = PlaceData(saveDate: Date(), place: place)
         placeContainer?.mainContext.insert(data)
     }
+    
+    @MainActor 
+    func loadUsers() {
+        let descriptor = FetchDescriptor<PlaceData>(sortBy: [SortDescriptor(\.saveDate)])
+        let places = (try? placeContainer?.mainContext.fetch(descriptor)) ?? []
+
+        places.forEach {
+            Log.info("\($0.saveDate) / (\($0.place)")
+        }
+    }
+
 }

--- a/GIL/GIL/Screen/PlaceSearch/PlaceSearchViewModel.swift
+++ b/GIL/GIL/Screen/PlaceSearch/PlaceSearchViewModel.swift
@@ -44,15 +44,4 @@ class PlaceSearchViewModel {
         let data = PlaceData(saveDate: Date(), place: place)
         placeContainer?.mainContext.insert(data)
     }
-    
-    @MainActor 
-    func loadUsers() {
-        let descriptor = FetchDescriptor<PlaceData>(sortBy: [SortDescriptor(\.saveDate)])
-        let places = (try? placeContainer?.mainContext.fetch(descriptor)) ?? []
-
-        places.forEach {
-            Log.info("\($0.saveDate) / (\($0.place)")
-        }
-    }
-
 }

--- a/GIL/GIL/Screen/PlaceSearch/PlaceSearchViewModel.swift
+++ b/GIL/GIL/Screen/PlaceSearch/PlaceSearchViewModel.swift
@@ -16,6 +16,10 @@ class PlaceSearchViewModel {
     
     var cancellables: Set<AnyCancellable> = []
     
+    init() {
+        locationService.requestLocation()
+    }
+    
     func searchPlace(_ query: String) {
         guard let location = locationService.currentLocation else { return }
         Task {

--- a/GIL/GIL/SwiftData/PlaceData.swift
+++ b/GIL/GIL/SwiftData/PlaceData.swift
@@ -1,0 +1,23 @@
+//
+//  PlaceData.swift
+//  GIL
+//
+//  Created by 송우진 on 4/30/24.
+//
+
+import Foundation
+import SwiftData
+
+@Model
+final class PlaceData {
+    var saveDate: Date
+    var place: Place
+    
+    init(
+        saveDate: Date,
+        place: Place
+    ) {
+        self.saveDate = saveDate
+        self.place = place
+    }
+}


### PR DESCRIPTION
홈 화면에 검색했던 장소를 보여주는 뷰를 구성했습니다.

- 검색 화면에서 장소를 클릭하면 SwiftData에 저장합니다.
- SwiftData를 사용하기 위해 최소 지원 버전을 17.0으로 변경했습니다.
- 장소는 최대 3개까지 노출되며 가장 최근 검색했던 순서대로 보여주도록 했습니다.
- 홈 화면에 진입할 때마다 새로운 데이터를 불러와 뷰를 업데이트하도록 했습니다.
- ViewController의 규모를 줄이기 위해 기능별로 코드를 여러 파일로 분리해봤습니다.

![Simulator Screenshot - iPhone 15 Plus - 2024-05-01 at 14 04 57](https://github.com/f-lab-edu/gil-navi-ios/assets/27650650/61655d60-3ff8-4f6d-a694-773372992c46)
