### PR TITLE
UIView 확장을 통한 뷰 레이아웃 제약 조건 관리 기능 추가 및 적용

### DIFF
--- a/GIL/GIL.xcodeproj/project.pbxproj
+++ b/GIL/GIL.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		583210B52BE6610300D9DCA1 /* signUpCollectionViewHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 583210B42BE6610300D9DCA1 /* signUpCollectionViewHandler.swift */; };
 		583210B82BE69EB700D9DCA1 /* CollectionViewCellProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 583210B72BE69EB700D9DCA1 /* CollectionViewCellProtocol.swift */; };
 		583210BA2BE76DAA00D9DCA1 /* BaseLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 583210B92BE76DAA00D9DCA1 /* BaseLabel.swift */; };
+		583210BC2BE8F24200D9DCA1 /* BaseImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 583210BB2BE8F24200D9DCA1 /* BaseImageView.swift */; };
 		58368EFC2BD536B8009E008C /* AlertService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58368EFB2BD536B8009E008C /* AlertService.swift */; };
 		58368F032BD80472009E008C /* HomeInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58368F022BD80472009E008C /* HomeInteractor.swift */; };
 		58368F052BD8047E009E008C /* HomePresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58368F042BD8047E009E008C /* HomePresenter.swift */; };
@@ -116,6 +117,7 @@
 		583210B42BE6610300D9DCA1 /* signUpCollectionViewHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = signUpCollectionViewHandler.swift; sourceTree = "<group>"; };
 		583210B72BE69EB700D9DCA1 /* CollectionViewCellProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectionViewCellProtocol.swift; sourceTree = "<group>"; };
 		583210B92BE76DAA00D9DCA1 /* BaseLabel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BaseLabel.swift; sourceTree = "<group>"; };
+		583210BB2BE8F24200D9DCA1 /* BaseImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseImageView.swift; sourceTree = "<group>"; };
 		58368EFB2BD536B8009E008C /* AlertService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertService.swift; sourceTree = "<group>"; };
 		58368F022BD80472009E008C /* HomeInteractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeInteractor.swift; sourceTree = "<group>"; };
 		58368F042BD8047E009E008C /* HomePresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomePresenter.swift; sourceTree = "<group>"; };
@@ -377,6 +379,7 @@
 				5810DE452BE35D4600180BFB /* BaseStackView.swift */,
 				5810DE472BE36A5700180BFB /* BaseButton.swift */,
 				583210B92BE76DAA00D9DCA1 /* BaseLabel.swift */,
+				583210BB2BE8F24200D9DCA1 /* BaseImageView.swift */,
 			);
 			path = Component;
 			sourceTree = "<group>";
@@ -663,6 +666,7 @@
 				58BDFBA22BB2B8F5006AC994 /* SignUpViewController.swift in Sources */,
 				58BAC8B02BCCF59800CDEB1F /* NavigationActionButton.swift in Sources */,
 				586F03162BE0FD9A008660A0 /* PlaceSearchViewController+UICollectionView.swift in Sources */,
+				583210BC2BE8F24200D9DCA1 /* BaseImageView.swift in Sources */,
 				58DE93062BDF79C600C97575 /* PlacesSearchService.swift in Sources */,
 				584FA4222BA84254002600F1 /* InteractiveButton.swift in Sources */,
 				58DE930D2BDF94B600C97575 /* PlaceModel.swift in Sources */,

--- a/GIL/GIL/Component/BaseImageView.swift
+++ b/GIL/GIL/Component/BaseImageView.swift
@@ -1,0 +1,36 @@
+//
+//  BaseImageView.swift
+//  GIL
+//
+//  Created by 송우진 on 5/6/24.
+//
+
+import UIKit
+
+class BaseImageView: UIImageView {
+    
+    // MARK: - Initialization
+    init(
+        image: UIImage?,
+        contentMode: UIView.ContentMode = .scaleToFill,
+        tintColor: UIColor? = nil
+    ) {
+        super.init(frame: .zero)
+        configure(image: image, contentMode: contentMode, tintColor: tintColor)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - Setup UI
+    private func configure(
+        image img: UIImage?,
+        contentMode mode: UIView.ContentMode,
+        tintColor color: UIColor?
+    ) {
+        image = img
+        contentMode = mode
+        tintColor = color
+    }
+}

--- a/GIL/GIL/Component/MappinImageView.swift
+++ b/GIL/GIL/Component/MappinImageView.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-final class MappinImageView: UIImageView {
+final class MappinImageView: BaseImageView {
     enum IconType {
         case filled
         case outline
@@ -25,23 +25,11 @@ final class MappinImageView: UIImageView {
         iconType: IconType,
         tintColor: UIColor = .mainGreen
     ) {
-        super.init(frame: .zero)
-        setupIcon(iconType: iconType, tintColor: tintColor)
+        let image = UIImage(systemName: iconType.imageName)
+        super.init(image: image, contentMode: .scaleAspectFit, tintColor: tintColor)
     }
     
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
-    }
-}
-
-// MARK: - Setup UI
-extension MappinImageView {
-    func setupIcon(
-        iconType: IconType,
-        tintColor color: UIColor
-    ) {
-        contentMode = .scaleAspectFit
-        tintColor = color
-        image = UIImage(systemName: iconType.imageName)
     }
 }

--- a/GIL/GIL/Extension/UIView+Extension.swift
+++ b/GIL/GIL/Extension/UIView+Extension.swift
@@ -39,3 +39,199 @@ extension UIView {
         case bottom = "bottomBorder"
     }
 }
+
+extension UIView {
+    private static var activeConstraints: NSMapTable<UIView, NSDictionary> = NSMapTable(keyOptions: .weakMemory, valueOptions: .strongMemory)
+
+    /// 현재 뷰에 연결된 제약 조건을 관리하는 속성입니다.
+    private var viewConstraints: [NSLayoutConstraint.Attribute: NSLayoutConstraint] {
+        get {
+            let constraintsDictionary = UIView.activeConstraints.object(forKey: self) as? [NSLayoutConstraint.Attribute: NSLayoutConstraint]
+            return constraintsDictionary ?? [:]
+        }
+        set {
+            UIView.activeConstraints.setObject(newValue as NSDictionary, forKey: self)
+        }
+    }
+    
+    /// 제약 조건을 활성화하고 필요하면 기존 제약을 비활성화합니다.
+    private func activateConstraint(
+        _ constraint: NSLayoutConstraint,
+        for attribute: NSLayoutConstraint.Attribute
+    ) {
+        translatesAutoresizingMaskIntoConstraints = false
+        
+        if let existingConstraint = viewConstraints[attribute] {
+            existingConstraint.isActive = false
+            removeConstraint(existingConstraint)
+        }
+
+        viewConstraints[attribute] = constraint
+        constraint.isActive = true
+    }
+
+    /// 주어진 앵커에 대해 왼쪽 제약을 추가합니다.
+    /// - Parameters:
+    ///   - anchor: 왼쪽 제약을 맞출 앵커
+    ///   - constant: 앵커와의 간격 (기본값은 0)
+    /// - Returns: 메서드를 호출한 UIView 객체를 반환합니다.
+    @discardableResult
+    func left(
+        equalTo anchor: NSLayoutXAxisAnchor,
+        constant: CGFloat = 0.0
+    ) -> UIView {
+        let constraint = leadingAnchor.constraint(equalTo: anchor, constant: constant)
+        activateConstraint(constraint, for: .leading)
+        return self
+    }
+
+    /// 주어진 앵커에 대해 오른쪽 제약을 추가합니다.
+    /// - Parameters:
+    ///   - anchor: 오른쪽 제약을 맞출 앵커
+    ///   - constant: 앵커와의 간격 (기본값은 0)
+    /// - Returns: 메서드를 호출한 UIView 객체를 반환합니다.
+    @discardableResult
+    func right(
+        equalTo anchor: NSLayoutXAxisAnchor,
+        constant: CGFloat = 0.0
+    ) -> UIView {
+        let constraint = trailingAnchor.constraint(equalTo: anchor, constant: constant)
+        activateConstraint(constraint, for: .trailing)
+        return self
+    }
+
+    /// 주어진 앵커에 대해 상단 제약을 추가합니다.
+    /// - Parameters:
+    ///   - anchor: 상단 제약을 맞출 앵커
+    ///   - constant: 앵커와의 간격 (기본값은 0)
+    /// - Returns: 메서드를 호출한 UIView 객체를 반환합니다.
+    @discardableResult
+    func top(
+        equalTo anchor: NSLayoutYAxisAnchor,
+        constant: CGFloat = 0.0
+    ) -> UIView {
+        let constraint = topAnchor.constraint(equalTo: anchor, constant: constant)
+        activateConstraint(constraint, for: .top)
+        return self
+    }
+
+    /// 주어진 앵커에 대해 하단 제약을 추가합니다.
+    /// - Parameters:
+    ///   - anchor: 하단 제약을 맞출 앵커
+    ///   - constant: 앵커와의 간격 (기본값은 0)
+    /// - Returns: 메서드를 호출한 UIView 객체를 반환합니다.
+    @discardableResult
+    func bottom(
+        equalTo anchor: NSLayoutYAxisAnchor,
+        constant: CGFloat = 0.0
+    ) -> UIView {
+        let constraint = bottomAnchor.constraint(equalTo: anchor, constant: constant)
+        activateConstraint(constraint, for: .bottom)
+        return self
+    }
+    
+    /// 주어진 앵커에 대해 가로 중심 제약을 추가합니다.
+    /// - Parameters:
+    ///   - anchor: 가로 중심 제약을 맞출 앵커
+    ///   - constant: 앵커와의 간격 (기본값은 0)
+    /// - Returns: 메서드를 호출한 UIView 객체를 반환합니다.
+    @discardableResult
+    func centerX(
+        equalTo anchor: NSLayoutXAxisAnchor,
+        constant: CGFloat = 0.0
+    ) -> UIView {
+        let constraint = centerXAnchor.constraint(equalTo: anchor, constant: constant)
+        activateConstraint(constraint, for: .centerX)
+        return self
+    }
+    
+    /// 주어진 앵커에 대해 세로 중심 제약을 추가합니다.
+    /// - Parameters:
+    ///   - anchor: 세로 중심 제약을 맞출 앵커
+    ///   - constant: 앵커와의 간격 (기본값은 0)
+    /// - Returns: 메서드를 호출한 UIView 객체를 반환합니다.
+    @discardableResult
+    func centerY(
+        equalTo anchor: NSLayoutYAxisAnchor,
+        constant: CGFloat = 0.0
+    ) -> UIView {
+        let constraint = centerYAnchor.constraint(equalTo: anchor, constant: constant)
+        activateConstraint(constraint, for: .centerY)
+        return self
+    }
+
+    /// 지정된 상수 값에 대한 너비 제약을 추가합니다.
+    /// - Parameter constant: 너비 값
+    /// - Returns: 메서드를 호출한 UIView 객체를 반환합니다.
+    @discardableResult
+    func width(_ constant: CGFloat) -> UIView {
+        let constraint = widthAnchor.constraint(equalToConstant: constant)
+        activateConstraint(constraint, for: .width)
+        return self
+    }
+    
+    /// 지정된 상수 값에 대한 높이 제약을 추가합니다.
+    /// - Parameter constant: 높이 값
+    /// - Returns: 메서드를 호출한 UIView 객체를 반환합니다.
+    @discardableResult
+    func height(_ constant: CGFloat) -> UIView {
+        let constraint = heightAnchor.constraint(equalToConstant: constant)
+        activateConstraint(constraint, for: .height)
+        return self
+    }
+    
+    /// 주어진 크기에 맞는 너비와 높이 제약을 추가합니다.
+    /// - Parameter size: 너비와 높이를 지정하는 CGSize 값
+    /// - Returns: 메서드를 호출한 UIView 객체를 반환합니다.
+    @discardableResult
+    func size(_ size: CGSize) -> UIView {
+        let widthConstraint = widthAnchor.constraint(equalToConstant: size.width)
+        activateConstraint(widthConstraint, for: .width)
+        
+        let heightConstraint = heightAnchor.constraint(equalToConstant: size.height)
+        activateConstraint(heightConstraint, for: .height)
+        return self
+    }
+    
+    /// 다른 뷰와 일치하는 속성에 대한 제약을 추가합니다.
+    /// - Parameters:
+    ///   - matchView: 제약을 맞출 대상 뷰
+    ///   - attributes: 적용할 제약의 속성 배열
+    /// - Returns: 메서드를 호출한 UIView 객체를 반환합니다.
+    @discardableResult
+    func applyConstraints(
+        to matchView: UIView,
+        attributes: [NSLayoutConstraint.Attribute]
+    ) -> UIView {
+        attributes.forEach { attribute in
+            switch attribute {
+            case .leading:
+                let constraint = leadingAnchor.constraint(equalTo: matchView.leadingAnchor)
+                activateConstraint(constraint, for: .leading)
+            case .trailing:
+                let constraint = trailingAnchor.constraint(equalTo: matchView.trailingAnchor)
+                activateConstraint(constraint, for: .trailing)
+            case .top:
+                let constraint = topAnchor.constraint(equalTo: matchView.topAnchor)
+                activateConstraint(constraint, for: .top)
+            case .bottom:
+                let constraint = bottomAnchor.constraint(equalTo: matchView.bottomAnchor)
+                activateConstraint(constraint, for: .bottom)
+            case .width:
+                let constraint = widthAnchor.constraint(equalTo: matchView.widthAnchor)
+                activateConstraint(constraint, for: .width)
+            case .height:
+                let constraint = heightAnchor.constraint(equalTo: matchView.heightAnchor)
+                activateConstraint(constraint, for: .height)
+            case .centerX:
+                let constraint = centerXAnchor.constraint(equalTo: matchView.centerXAnchor)
+                activateConstraint(constraint, for: .centerX)
+            case .centerY:
+                let constraint = centerYAnchor.constraint(equalTo: matchView.centerYAnchor)
+                activateConstraint(constraint, for: .centerY)
+            default: break
+            }
+        }
+        return self
+    }
+}

--- a/GIL/GIL/Model/PlaceModel.swift
+++ b/GIL/GIL/Model/PlaceModel.swift
@@ -22,4 +22,12 @@ struct Place: Hashable, Codable {
         self.category = mapItem.pointOfInterestCategory?.rawValue ?? ""
         self.distance = distance
     }
+    
+    func formattedDistanceString() -> String {
+        if distance < 1000 {
+            return "\(Int(distance))m"
+        } else {
+            return String(format: "%.2fkm", distance / 1000)
+        }
+    }
 }

--- a/GIL/GIL/Screen/Home/Cells/HomeRecentSearchPlaceCollectionViewCell.swift
+++ b/GIL/GIL/Screen/Home/Cells/HomeRecentSearchPlaceCollectionViewCell.swift
@@ -7,48 +7,54 @@
 
 import UIKit
 
-class HomeRecentSearchPlaceCollectionViewCell: UICollectionViewCell, CollectionViewCellProtocol {
+final class HomeRecentSearchPlaceCollectionViewCell: UICollectionViewCell, CollectionViewCellProtocol {
     static let reuseIdentifier = "HomeRecentSearchPlaceCell"
+    private let stackView = BaseStackView(spacing: 10)
     private var buttons: [UIButton] = []
     
+    // MARK: - Initialization
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupUI()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+// MARK: - Setup UI
+extension HomeRecentSearchPlaceCollectionViewCell {
+    private func setupUI() {
+        contentView.addSubview(stackView)
+        stackView.applyConstraints(to: contentView, attributes: [.top, .bottom, .leading, .trailing])
+    }
 }
 
 // MARK: - Configure Cell
 extension HomeRecentSearchPlaceCollectionViewCell {
     func configure(with places: [PlaceData]) {
-        cleanupButtons()
+        cleanup()
         configureButtons(with: places)
     }
     
-    private func cleanupButtons() {
+    private func cleanup() {
+        stackView.arrangedSubviews.forEach {
+            stackView.removeArrangedSubview($0)
+            $0.removeFromSuperview()
+        }
+        
         buttons.forEach { $0.removeFromSuperview() }
         buttons.removeAll()
     }
     
     private func configureButtons(with places: [PlaceData]) {
-        var previousButton: UIButton? = nil
         for place in places {
             let button = createButton(for: place)
-            buttons.append(button)
-            contentView.addSubview(button)
-            button.translatesAutoresizingMaskIntoConstraints = false
-            
-            NSLayoutConstraint.activate([
-                button.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 16),
-                button.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -16),
-                button.topAnchor.constraint(equalTo: previousButton?.bottomAnchor ?? contentView.topAnchor, constant: 10)
-            ])
-            previousButton = button
-            
-            button.layoutIfNeeded()
-            button.addBorder(at: .bottom, color: .lightGrayBorder)
-        }
-        if let lastButton = buttons.last {
-            lastButton.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -10).isActive = true
+            stackView.addArrangedSubview(button)
         }
     }
 }
-
 
 // MARK: - Button Creation and Layout
 extension HomeRecentSearchPlaceCollectionViewCell {
@@ -59,32 +65,37 @@ extension HomeRecentSearchPlaceCollectionViewCell {
         let iconImageView = MappinImageView(iconType: .filled)
         let nameLabel = BaseLabel(text: place.place.name, fontSize: 15, fontWeight: .bold)
         let addressLabel = BaseLabel(text: place.place.address, fontSize: 13, fontWeight: .medium)
-        
-        [iconImageView, nameLabel, addressLabel].forEach({
-            button.addSubview($0)
-            $0.translatesAutoresizingMaskIntoConstraints = false
-        })
-        
-        setupButtonLayout(button: button, icon: iconImageView, name: nameLabel, address: addressLabel)
-        
+        let border = UIView()
+        border.backgroundColor = .lightGrayBorder
+    
+        [iconImageView, nameLabel, addressLabel, border].forEach({ button.addSubview($0) })
+        setupButtonLayout(button: button, icon: iconImageView, name: nameLabel, address: addressLabel, border: border)
         return button
     }
     
-    private func setupButtonLayout(button: UIButton, icon: UIImageView, name: UILabel, address: UILabel) {
-        NSLayoutConstraint.activate([
-            icon.leadingAnchor.constraint(equalTo: button.leadingAnchor, constant: 10),
-            icon.centerYAnchor.constraint(equalTo: button.centerYAnchor),
-            icon.widthAnchor.constraint(equalToConstant: 30),
-            icon.heightAnchor.constraint(equalToConstant: 30),
-            
-            name.leadingAnchor.constraint(equalTo: icon.trailingAnchor, constant: 10),
-            name.trailingAnchor.constraint(equalTo: button.trailingAnchor, constant: -10),
-            name.topAnchor.constraint(equalTo: button.topAnchor, constant: 10),
-            
-            address.leadingAnchor.constraint(equalTo: name.leadingAnchor),
-            address.trailingAnchor.constraint(equalTo: name.trailingAnchor),
-            address.topAnchor.constraint(equalTo: name.bottomAnchor, constant: 5),
-            address.bottomAnchor.constraint(equalTo: button.bottomAnchor, constant: -10)
-        ])
+    private func setupButtonLayout(
+        button: UIButton,
+        icon: UIImageView,
+        name: UILabel,
+        address: UILabel,
+        border: UIView
+    ) {
+        icon
+            .left(equalTo: button.leadingAnchor, constant: 26)
+            .centerY(equalTo: button.centerYAnchor)
+            .size(CGSize(width: 30, height: 30))
+        name
+            .left(equalTo: icon.trailingAnchor, constant: 10)
+            .right(equalTo: button.trailingAnchor, constant: -26)
+            .top(equalTo: button.topAnchor, constant: 10)
+        address
+            .top(equalTo: name.bottomAnchor, constant: 5)
+            .bottom(equalTo: button.bottomAnchor, constant: -10)
+            .applyConstraints(to: name, attributes: [.leading, .trailing])
+        border
+            .bottom(equalTo: button.bottomAnchor)
+            .left(equalTo: button.leadingAnchor, constant: 20)
+            .right(equalTo: button.trailingAnchor, constant: -20)
+            .height(1)
     }
 }

--- a/GIL/GIL/Screen/Home/Cells/HomeSearchCollectionViewCell.swift
+++ b/GIL/GIL/Screen/Home/Cells/HomeSearchCollectionViewCell.swift
@@ -7,36 +7,26 @@
 
 import UIKit
 
-class HomeSearchCollectionViewCell: UICollectionViewCell, CollectionViewCellProtocol {
+final class HomeSearchCollectionViewCell: UICollectionViewCell, CollectionViewCellProtocol {
     static let reuseIdentifier = "HomeSearchCell"
-    let searchBarView = HomeSearchBarView()
+    private let searchBarView = HomeSearchBarView()
     var onSearchBarTapped: (() -> Void)?
     
     // MARK: - Initialization
     override init(frame: CGRect) {
         super.init(frame: frame)
-        configureUI()
-        setupBindings()
+        setupUI()
+        setupBindTapGesture()
     }
     
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-    
-    // MARK: - Drawing Cycle
-    override func updateConstraints() {
-        setConstraints()
-        super.updateConstraints()
-    }
 }
 
-// MARK: - Binding
+// MARK: - Setup Binding
 extension HomeSearchCollectionViewCell {
-    func setupBindings() {
-        bindTapGesture()
-    }
-    
-    private func bindTapGesture() {
+    private func setupBindTapGesture() {
         let tapGesture = UITapGestureRecognizer(target: self, action: #selector(searchBarTapped))
         searchBarView.addGestureRecognizer(tapGesture)
     }
@@ -49,21 +39,22 @@ extension HomeSearchCollectionViewCell {
     }
 }
 
-// MARK: - Configure UI
+// MARK: - Setup UI
 extension HomeSearchCollectionViewCell {
-    func configureUI() {
-        contentView.addSubview(searchBarView)
-        searchBarView.translatesAutoresizingMaskIntoConstraints = false
-        
-        setNeedsUpdateConstraints()
+    private func setupUI() {
+        addSubviews()
+        setupSearchBarView()
     }
     
-    func setConstraints() {
-        NSLayoutConstraint.activate([
-            searchBarView.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
-            searchBarView.leftAnchor.constraint(equalTo: contentView.leftAnchor, constant: 10),
-            searchBarView.rightAnchor.constraint(equalTo: contentView.rightAnchor, constant: -10),
-            searchBarView.heightAnchor.constraint(equalToConstant: 50)
-        ])
+    private func addSubviews() {
+        contentView.addSubview(searchBarView)
+    }
+    
+    private func setupSearchBarView() {
+        searchBarView
+            .centerY(equalTo: contentView.centerYAnchor)
+            .left(equalTo: contentView.leadingAnchor, constant: 10)
+            .right(equalTo: contentView.trailingAnchor, constant: -10)
+            .height(50)
     }
 }

--- a/GIL/GIL/Screen/Home/Views/HomeSearchBarView.swift
+++ b/GIL/GIL/Screen/Home/Views/HomeSearchBarView.swift
@@ -8,79 +8,58 @@
 import UIKit
 
 final class HomeSearchBarView: UIView {
-    private let searchIconImageView: UIImageView = {
-        let imageView = UIImageView()
-        imageView.image = UIImage(systemName: "magnifyingglass")
-        imageView.contentMode = .scaleAspectFit
-        return imageView
-    }()
-
-    let searchLabel: UILabel = {
-        let label = UILabel()
-        label.text = "어디로 갈까요?".localized()
-        label.textColor = .placeholder
-        label.applyDynamicTypeFont(textStyle: .body, size: 15, weight: .regular)
-        return label
-    }()
-
-    private let favoriteButton: UIButton = {
-        let button = UIButton(type: .system)
-        button.setImage(UIImage(systemName: "heart"), for: .normal)
-        return button
-    }()
+    private let searchIconImageView = BaseImageView(image: UIImage(systemName: "magnifyingglass"), contentMode: .scaleAspectFit, tintColor: .placeholder)
+    private let searchLabel = BaseLabel(text: "어디로 갈까요?", textColor: .placeholder, fontWeight: .regular)
 
     // MARK: - Initialization
     override init(frame: CGRect) {
         super.init(frame: frame)
-        configureUI()
+        setupUI()
     }
     
     required init?(coder: NSCoder) {
-        super.init(coder: coder)
-        
-    }
-    
-    // MARK: - Drawing Cycle
-    override func updateConstraints() {
-        setConstraints()
-        super.updateConstraints()
+        fatalError("init(coder:) has not been implemented")
     }
 }
 
-// MARK: - Configure UI
+// MARK: - Setup UI
 extension HomeSearchBarView {
-    func configureUI() {
-        layer.cornerRadius = 3
+    private func setupUI() {
+        setupView()
+        addSubviews()
+        setupComponents()
+    }
+    
+    private func setupView() {
         backgroundColor = .white
-        
+        layer.cornerRadius = 3
         layer.shadowColor = UIColor.black.cgColor
         layer.shadowOffset = CGSize(width: 0, height: 1)
         layer.shadowRadius = 3
         layer.shadowOpacity = 0.2
         clipsToBounds = false
-        
-        [searchIconImageView, searchLabel, favoriteButton].forEach({
-            addSubview($0)
-            $0.translatesAutoresizingMaskIntoConstraints = false
-        })
     }
     
-    func setConstraints() {
-        NSLayoutConstraint.activate([
-            searchIconImageView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 8),
-            searchIconImageView.centerYAnchor.constraint(equalTo: centerYAnchor),
-            searchIconImageView.widthAnchor.constraint(equalToConstant: 24),
-            searchIconImageView.heightAnchor.constraint(equalToConstant: 24),
-            
-            searchLabel.leadingAnchor.constraint(equalTo: searchIconImageView.trailingAnchor, constant: 8),
-            searchLabel.trailingAnchor.constraint(equalTo: favoriteButton.leadingAnchor, constant: -8),
-            searchLabel.topAnchor.constraint(equalTo: topAnchor, constant: 8),
-            searchLabel.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -8),
-            
-            favoriteButton.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -8),
-            favoriteButton.centerYAnchor.constraint(equalTo: centerYAnchor),
-            favoriteButton.widthAnchor.constraint(equalToConstant: 24),
-            favoriteButton.heightAnchor.constraint(equalToConstant: 24)
-        ])
+    private func addSubviews() {
+        [searchIconImageView, searchLabel].forEach({ addSubview($0) })
+    }
+
+    private func setupComponents() {
+        setupSearchIconImageView()
+        setupSearchLabel()
+    }
+    
+    private func setupSearchIconImageView() {
+        searchIconImageView
+            .left(equalTo: leadingAnchor, constant: 8)
+            .centerY(equalTo: centerYAnchor)
+            .size(CGSize(width: 24, height: 24))
+    }
+    
+    private func setupSearchLabel() {
+        searchLabel
+            .left(equalTo: searchIconImageView.trailingAnchor, constant: 8)
+            .right(equalTo: trailingAnchor, constant: -8)
+            .centerY(equalTo: searchIconImageView.centerYAnchor)
     }
 }

--- a/GIL/GIL/Screen/Home/Views/HomeView.swift
+++ b/GIL/GIL/Screen/Home/Views/HomeView.swift
@@ -8,7 +8,6 @@
 import UIKit
 
 final class HomeView: UIView {
-    
     lazy var mainCollectionView: UICollectionView = {
         let layout = UICollectionViewFlowLayout()
         layout.scrollDirection = .vertical
@@ -22,35 +21,26 @@ final class HomeView: UIView {
     // MARK: - Initialization
     override init(frame: CGRect) {
         super.init(frame: frame)
-        configureUI()
+        setupUI()
     }
     
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-    
-    // MARK: - Drawing Cycle
-    override func updateConstraints() {
-        setConstraints()
-        super.updateConstraints()
-    }
 }
 
-// MARK: - Configure UI
+// MARK: - Setup UI
 extension HomeView {
-    func configureUI() {
-        [mainCollectionView].forEach({
-            addSubview($0)
-            $0.translatesAutoresizingMaskIntoConstraints = false
-        })
+    private func setupUI() {
+        addSubviews()
+        setupMainCollectionView()
     }
     
-    func setConstraints() {
-        NSLayoutConstraint.activate([
-            mainCollectionView.topAnchor.constraint(equalTo: safeAreaLayoutGuide.topAnchor),
-            mainCollectionView.leftAnchor.constraint(equalTo: leftAnchor),
-            mainCollectionView.bottomAnchor.constraint(equalTo: bottomAnchor),
-            mainCollectionView.rightAnchor.constraint(equalTo: rightAnchor)
-        ])
+    private func addSubviews() {
+        addSubview(mainCollectionView)
+    }
+    
+    private func setupMainCollectionView() {
+        mainCollectionView.applyConstraints(to: self, attributes: [.top, .bottom, .leading, .trailing])
     }
 }

--- a/GIL/GIL/Screen/Login/LoginView.swift
+++ b/GIL/GIL/Screen/Login/LoginView.swift
@@ -6,7 +6,6 @@
 //
 
 import UIKit
-import AuthenticationServices
 
 final class LoginView: UIView {
     private let formStackView = BaseStackView(axis: .vertical, spacing: 10)
@@ -28,55 +27,62 @@ final class LoginView: UIView {
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-    
-    // MARK: - Drawing Cycle
-    override func updateConstraints() {
-        setConstraints()
-        super.updateConstraints()
 
-    }
 }
 
-// MARK: - Configure UI
+// MARK: - Setup UI
 extension LoginView {
-    func configureUI() {
-        [emailTextField, passwordTextField, loginButton, stackView, border, socialLabel, appleLoginButton].forEach({
-            addSubview($0)
-            $0.translatesAutoresizingMaskIntoConstraints = false
-        })
-        
-        [signUpLabel, signUpButton].forEach({
-            stackView.addArrangedSubview($0)
-        })
-        
+    private func setupUI() {
+        addSubviews()
+        setupComponents()
     }
     
-    func setConstraints() {
-        NSLayoutConstraint.activate([
-            emailTextField.topAnchor.constraint(equalTo: topAnchor, constant: 120),
-            emailTextField.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 16),
-            emailTextField.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -16),
-            emailTextField.heightAnchor.constraint(equalToConstant: 55),
-            passwordTextField.topAnchor.constraint(equalTo: emailTextField.bottomAnchor, constant: 10),
-            passwordTextField.leadingAnchor.constraint(equalTo: emailTextField.leadingAnchor),
-            passwordTextField.trailingAnchor.constraint(equalTo: emailTextField.trailingAnchor),
-            passwordTextField.heightAnchor.constraint(equalTo: emailTextField.heightAnchor),
-            loginButton.topAnchor.constraint(equalTo: passwordTextField.bottomAnchor, constant: 30),
-            loginButton.leadingAnchor.constraint(equalTo: passwordTextField.leadingAnchor),
-            loginButton.trailingAnchor.constraint(equalTo: passwordTextField.trailingAnchor),
-            loginButton.heightAnchor.constraint(equalToConstant: 60),
-            stackView.topAnchor.constraint(equalTo: loginButton.bottomAnchor, constant: 40),
-            stackView.centerXAnchor.constraint(equalTo: centerXAnchor),
-            border.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -120),
-            border.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 30),
-            border.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -30),
-            border.heightAnchor.constraint(equalToConstant: 1),
-            socialLabel.centerXAnchor.constraint(equalTo: border.centerXAnchor),
-            socialLabel.centerYAnchor.constraint(equalTo: border.centerYAnchor),
-            appleLoginButton.topAnchor.constraint(equalTo: border.bottomAnchor, constant: 20),
-            appleLoginButton.centerXAnchor.constraint(equalTo: border.centerXAnchor),
-            appleLoginButton.widthAnchor.constraint(equalToConstant: 50),
-            appleLoginButton.heightAnchor.constraint(equalToConstant: 50)
-        ])
+    private func addSubviews() {
+        [formStackView, loginButton, singUpStackView, socialLabel, appleLoginButton].forEach({ addSubview($0) })
+        [emailTextField, passwordTextField].forEach({ formStackView.addArrangedSubview($0) })
+        [signUpLabel, signUpButton].forEach({ singUpStackView.addArrangedSubview($0) })
+    }
+    
+    private func setupComponents() {
+        setupFormStackView()
+        setupLoginButton()
+        setupSingUpStackView()
+        setupSocialLabel()
+        setupAppleLoginButton()
+    }
+    
+    private func setupFormStackView() {
+        formStackView
+            .top(equalTo: topAnchor, constant: 120)
+            .left(equalTo: leadingAnchor, constant: 16)
+            .right(equalTo: trailingAnchor, constant: -16)
+            .height(120)
+    }
+    
+    private func setupLoginButton() {
+        loginButton
+            .top(equalTo: formStackView.bottomAnchor, constant: 30)
+            .applyConstraints(to: formStackView, attributes: [.leading, .trailing])
+            .height(60)
+    }
+    
+    private func setupSingUpStackView() {
+        singUpStackView
+            .top(equalTo: loginButton.bottomAnchor, constant: 40)
+            .centerX(equalTo: centerXAnchor)
+    }
+    
+    private func setupSocialLabel() {
+        socialLabel
+            .centerX(equalTo: centerXAnchor)
+            .bottom(equalTo: bottomAnchor, constant: -120)
+    }
+    
+    private func setupAppleLoginButton() {
+        appleLoginButton.layer.cornerRadius = 25
+        appleLoginButton
+            .top(equalTo: socialLabel.bottomAnchor, constant: 20)
+            .centerX(equalTo: socialLabel.centerXAnchor)
+            .size(CGSize(width: 50, height: 50))
     }
 }

--- a/GIL/GIL/Screen/PlaceSearch/Cells/PlaceSearchCollectionViewCell.swift
+++ b/GIL/GIL/Screen/PlaceSearch/Cells/PlaceSearchCollectionViewCell.swift
@@ -8,16 +8,11 @@
 import UIKit
 
 class PlaceSearchCollectionViewCell: UICollectionViewCell, CollectionViewCellProtocol {
-    static let reuseIdentifier: String = "PlaceSearchCell"
+    static let reuseIdentifier = "PlaceSearchCell"
     private let mappinIcon = MappinImageView(iconType: .outline)
-    private let stackView: UIStackView = {
-        let stack = UIStackView()
-        stack.axis = .vertical
-        stack.spacing = 5
-        return stack
-    }()
-    let nameLabel = BaseLabel(text: "", fontSize: 15, fontWeight: .bold)
-    let addressLabel = BaseLabel(text: "", textColor: .grayLabel, fontSize: 13, fontWeight: .medium, numberOfLines: 0)
+    private let stackView = BaseStackView(distribution: .equalCentering,spacing: 5)
+    private let nameLabel = BaseLabel(text: "", fontSize: 15, fontWeight: .bold)
+    private let addressLabel = BaseLabel(text: "", textColor: .grayLabel, fontSize: 13, fontWeight: .medium, numberOfLines: 0)
     
     // MARK: - Initialization
     override init(frame: CGRect) {
@@ -28,42 +23,37 @@ class PlaceSearchCollectionViewCell: UICollectionViewCell, CollectionViewCellPro
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-    
-    // MARK: - Drawing Cycle
-    override func updateConstraints() {
-        setConstraints()
-        super.updateConstraints()
-    }
 }
 
 // MARK: - Setup UI
 extension PlaceSearchCollectionViewCell {
-    func setupUI() {
+    private func setupUI() {
         contentView.addBorder(at: .bottom)
-        
-        [mappinIcon, stackView].forEach({
-            contentView.addSubview($0)
-            $0.translatesAutoresizingMaskIntoConstraints = false
-        })
-        
-        [nameLabel, addressLabel].forEach({
-            stackView.addArrangedSubview($0)
-        })
-        
-        setNeedsUpdateConstraints()
+        addSubviews()
+        setupComponents()
     }
     
-    func setConstraints() {
-        NSLayoutConstraint.activate([
-            mappinIcon.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
-            mappinIcon.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
-            mappinIcon.widthAnchor.constraint(equalToConstant: 30),
-            mappinIcon.heightAnchor.constraint(equalToConstant: 30),
-            
-            stackView.centerYAnchor.constraint(equalTo: mappinIcon.centerYAnchor),
-            stackView.leadingAnchor.constraint(equalTo: mappinIcon.trailingAnchor, constant: 11),
-            stackView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -11)
-        ])
+    private func addSubviews() {
+        [mappinIcon, stackView].forEach({ contentView.addSubview($0) })
+        [nameLabel, addressLabel].forEach({ stackView.addArrangedSubview($0) })
+    }
+    
+    private func setupComponents() {
+        setupMappinIcon()
+        setupStackView()
+    }
+    
+    private func setupMappinIcon() {
+        mappinIcon
+            .size(CGSize(width: 30, height: 30))
+            .applyConstraints(to: contentView, attributes: [.centerY, .leading])
+    }
+    
+    private func setupStackView() {
+        stackView
+            .centerY(equalTo: mappinIcon.centerYAnchor)
+            .left(equalTo: mappinIcon.trailingAnchor, constant: 11)
+            .right(equalTo: contentView.trailingAnchor, constant: -11)
     }
 }
 

--- a/GIL/GIL/Screen/PlaceSearch/Cells/PlaceSearchCollectionViewCell.swift
+++ b/GIL/GIL/Screen/PlaceSearch/Cells/PlaceSearchCollectionViewCell.swift
@@ -60,21 +60,8 @@ extension PlaceSearchCollectionViewCell {
 // MARK: - Update Content
 extension PlaceSearchCollectionViewCell {
     func updateContent(with item: Place) {
+        let viewModel = PlaceSearchViewModel()
         nameLabel.text = item.name
-        
-        if item.distance > 0 {
-            let formattedDistance = formatDistance(item.distance)
-            addressLabel.text = "\(formattedDistance) · \(item.address)"
-        } else {
-            addressLabel.text = item.address
-        }
-    }
-
-    private func formatDistance(_ distance: Double) -> String {
-        if distance < 1000 {
-            return "\(Int(distance))m"
-        } else {
-            return String(format: "%.2fkm", distance / 1000)
-        }
+        addressLabel.text = viewModel.getAddressForPlace(item)
     }
 }

--- a/GIL/GIL/Screen/PlaceSearch/PlaceSearchViewModel.swift
+++ b/GIL/GIL/Screen/PlaceSearch/PlaceSearchViewModel.swift
@@ -44,4 +44,13 @@ class PlaceSearchViewModel {
         let data = PlaceData(saveDate: Date(), place: place)
         placeContainer?.mainContext.insert(data)
     }
+    
+    func getAddressForPlace(_ place: Place) -> String {
+        if place.distance > 0 {
+            let formattedDistance = place.formattedDistanceString()
+            return "\(formattedDistance) · \(place.address)"
+        } else {
+            return place.address
+        }
+    }
 }

--- a/GIL/GIL/Screen/PlaceSearch/Views/PlaceSearchNavigationBar.swift
+++ b/GIL/GIL/Screen/PlaceSearch/Views/PlaceSearchNavigationBar.swift
@@ -8,8 +8,8 @@
 import UIKit
 
 final class PlaceSearchNavigationBar: UIView {
+    private let myLocationLabel = BaseLabel(text: "내 위치".localized(), fontSize: 11, fontWeight: .regular)
     let backButton = NavigationActionButton(type: .back)
-    let myLocationLabel = BaseLabel(text: "내 위치".localized(), fontSize: 11, fontWeight: .regular)
     let addressLabel = BaseLabel(text: "", textColor: .blackLabel, fontSize: 13, fontWeight: .bold)
     let searchBar = UISearchBar()
     
@@ -22,23 +22,32 @@ final class PlaceSearchNavigationBar: UIView {
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-    
-    // MARK: - Drawing Cycle
-    override func updateConstraints() {
-        setConstraints()
-        super.updateConstraints()
-    }
 }
 
 // MARK: - Setup UI
 extension PlaceSearchNavigationBar {
     private func setupUI() {
+        backgroundColor = .systemBackground
+        addSubviews()
+        setupComponents()
+    }
+    
+    private func addSubviews() {
+        [backButton, myLocationLabel, addressLabel, searchBar].forEach({ addSubview($0) })
+    }
+    
+    private func setupComponents() {
+        setupBackButton()
         setupSearchBar()
-
-        [backButton, myLocationLabel, addressLabel, searchBar].forEach({
-            addSubview($0)
-            $0.translatesAutoresizingMaskIntoConstraints = false
-        })
+        setupMyLocationLabel()
+        setupAddressLabel()
+    }
+    
+    private func setupBackButton() {
+        backButton
+            .top(equalTo: topAnchor)
+            .left(equalTo: leadingAnchor, constant: 11)
+            .size(CGSize(width: 36, height: 30))
     }
     
     private func setupSearchBar() {
@@ -48,26 +57,25 @@ extension PlaceSearchNavigationBar {
         searchBar.layer.borderColor = UIColor.lightGray.cgColor
         searchBar.layer.borderWidth = 1
         searchBar.searchTextField.borderStyle = .none
+        
+        searchBar
+            .top(equalTo: backButton.bottomAnchor, constant: 10)
+            .left(equalTo: leadingAnchor, constant: 16)
+            .right(equalTo: trailingAnchor, constant: -16)
+            .height(40)
     }
     
-    private func setConstraints() {
-        NSLayoutConstraint.activate([
-            backButton.topAnchor.constraint(equalTo: topAnchor),
-            backButton.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 11),
-            backButton.widthAnchor.constraint(equalToConstant: 36),
-            backButton.heightAnchor.constraint(equalToConstant: 30),
-            
-            myLocationLabel.topAnchor.constraint(equalTo: topAnchor),
-            myLocationLabel.leadingAnchor.constraint(equalTo: backButton.trailingAnchor, constant: 8),
-            
-            addressLabel.topAnchor.constraint(equalTo: myLocationLabel.bottomAnchor),
-            addressLabel.leadingAnchor.constraint(equalTo: myLocationLabel.leadingAnchor),
-            addressLabel.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -11),
-            
-            searchBar.topAnchor.constraint(equalTo: backButton.bottomAnchor, constant: 10),
-            searchBar.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 16),
-            searchBar.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -16),
-            searchBar.heightAnchor.constraint(equalToConstant: 40)
-        ])
+    private func setupMyLocationLabel() {
+        myLocationLabel
+            .top(equalTo: topAnchor)
+            .left(equalTo: backButton.trailingAnchor, constant: 8)
+    }
+    
+    private func setupAddressLabel() {
+        addressLabel
+            .top(equalTo: myLocationLabel.bottomAnchor)
+            .left(equalTo: myLocationLabel.leadingAnchor)
+            .right(equalTo: trailingAnchor, constant: -11)
     }
 }
+

--- a/GIL/GIL/Screen/PlaceSearch/Views/PlaceSearchView.swift
+++ b/GIL/GIL/Screen/PlaceSearch/Views/PlaceSearchView.swift
@@ -27,36 +27,34 @@ final class PlaceSearchView: UIView {
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-    
-    // MARK: - Drawing Cycle
-    override func updateConstraints() {
-        setConstraints()
-        super.updateConstraints()
-    }
 }
-
 // MARK: - Setup UI
 extension PlaceSearchView {
-    func setupUI() {
+    private func setupUI() {
         backgroundColor = .systemBackground
-
-        [navigationBar, searchResultsCollectionView].forEach({
-            addSubview($0)
-            $0.translatesAutoresizingMaskIntoConstraints = false
-        })
+        addSubviews()
+        setupComponents()
     }
     
-    func setConstraints() {
-        NSLayoutConstraint.activate([
-            navigationBar.topAnchor.constraint(equalTo: safeAreaLayoutGuide.topAnchor),
-            navigationBar.leadingAnchor.constraint(equalTo: leadingAnchor),
-            navigationBar.trailingAnchor.constraint(equalTo: trailingAnchor),
-            navigationBar.heightAnchor.constraint(equalToConstant: 80),
-            
-            searchResultsCollectionView.topAnchor.constraint(equalTo: navigationBar.bottomAnchor),
-            searchResultsCollectionView.leadingAnchor.constraint(equalTo: leadingAnchor),
-            searchResultsCollectionView.trailingAnchor.constraint(equalTo: trailingAnchor),
-            searchResultsCollectionView.bottomAnchor.constraint(equalTo: bottomAnchor)
-        ])
+    private func addSubviews() {
+        [navigationBar, searchResultsCollectionView].forEach({ addSubview($0) })
+    }
+    
+    private func setupComponents() {
+        setupNavigationBar()
+        setupCollectionView()
+    }
+    
+    private func setupNavigationBar() {
+        navigationBar
+            .top(equalTo: safeAreaLayoutGuide.topAnchor)
+            .height(80)
+            .applyConstraints(to: self, attributes: [.leading, .trailing])
+    }
+    
+    private func setupCollectionView() {
+        searchResultsCollectionView
+            .top(equalTo: navigationBar.bottomAnchor)
+            .applyConstraints(to: self, attributes: [.leading, .trailing, .bottom])
     }
 }

--- a/GIL/GIL/Screen/SignUp/SignUpView.swift
+++ b/GIL/GIL/Screen/SignUp/SignUpView.swift
@@ -9,6 +9,8 @@ import UIKit
 
 final class SignUpView: UIView {
     private let checkPasswordStackView = BaseStackView(spacing: 5)
+    private let checkPasswordLabels: [UILabel]
+    private var labelConstraints: [UILabel : NSLayoutConstraint]
     let closeButton = NavigationActionButton()
     let emailLabel = BaseLabel(text: "이메일", textColor: .mainGreen, fontType: .subheadline)
     let nameLabel = BaseLabel(text: "이름", textColor: .mainGreen, fontType: .subheadline)
@@ -19,18 +21,21 @@ final class SignUpView: UIView {
     let passwordTextField = FormTextField(type: .password, returnKeyType: .next)
     let verifyPasswordTextField = FormTextField(type: .verifyPassword, returnKeyType: .done)
     let doneButton = InteractiveButton(title: "완료", titleColor: .white, fontSize: 18, fontWeight: .bold)
-    let checkPasswordLabel_01 = BaseLabel(text: "· 10글자 이상", fontSize: 11)
-    let checkPasswordLabel_02 = BaseLabel(text: "· 대문자 포함", fontSize: 11)
-    let checkPasswordLabel_03 = BaseLabel(text: "· 숫자 포함", fontSize: 11)
-    let checkPasswordLabel_04 = BaseLabel(text: "· 특수 문자 포함 !@#$%^&*()-_=+[{]}\\|;:'\",<.>/?", fontSize: 11)
-    
-    lazy var emailLabelHeightConstraint: NSLayoutConstraint = emailLabel.heightAnchor.constraint(equalToConstant: 0)
-    lazy var nameLabelHeightConstraint: NSLayoutConstraint = nameLabel.heightAnchor.constraint(equalToConstant: 0)
-    lazy var passwordLabelHeightConstraint: NSLayoutConstraint = passwordLabel.heightAnchor.constraint(equalToConstant: 0)
-    lazy var verifyPasswordLabelHeightConstraint: NSLayoutConstraint = verifyPasswordLabel.heightAnchor.constraint(equalToConstant: 0)
     
     // MARK: - Initialization
     override init(frame: CGRect) {
+        checkPasswordLabels = [
+            BaseLabel(text: "· 10글자 이상", fontSize: 11),
+            BaseLabel(text: "· 대문자 포함", fontSize: 11),
+            BaseLabel(text: "· 숫자 포함", fontSize: 11),
+            BaseLabel(text: "· 특수 문자 포함 !@#$%^&*()-_=+[{]}\\|;:'\",<.>/?", fontSize: 11)
+        ]
+        labelConstraints = [
+            emailLabel : emailLabel.heightAnchor.constraint(equalToConstant: 0),
+            nameLabel : nameLabel.heightAnchor.constraint(equalToConstant: 0),
+            passwordLabel : passwordLabel.heightAnchor.constraint(equalToConstant: 0),
+            verifyPasswordLabel : verifyPasswordLabel.heightAnchor.constraint(equalToConstant: 0)
+        ]
         super.init(frame: frame)
         setupUI()
     }
@@ -44,11 +49,11 @@ final class SignUpView: UIView {
 extension SignUpView {
     func animateLabelVisibility(
         _ label: UILabel,
-        shouldShow: Bool,
-        constraint: NSLayoutConstraint
+        shouldShow: Bool
     ) {
+        let constraint = getConstraintForLabel(label)
         UIView.animate(withDuration: 0.3) {
-            label.alpha = shouldShow ? 1.0 : 0
+            label.alpha = shouldShow ? 1 : 0
             constraint.constant = shouldShow ? 16 : 0
             self.setupComponents()
             self.layoutIfNeeded()
@@ -56,11 +61,15 @@ extension SignUpView {
     }
     
     func updatePasswordValidationLabels(_ validations: [Bool]) {
-        let labels = [ checkPasswordLabel_01, checkPasswordLabel_02, checkPasswordLabel_03, checkPasswordLabel_04]
-        for (index, label) in labels.enumerated() {
+        for (index, label) in checkPasswordLabels.enumerated() {
             let isValid = (index < validations.count) ? validations[index] : false
             label.textColor = isValid ? .mainGreen : .text
         }
+    }
+    
+    private func getConstraintForLabel(_ label: UILabel) -> NSLayoutConstraint {
+        let constraint = labelConstraints[label]
+        return constraint ?? label.heightAnchor.constraint(equalToConstant: 0)
     }
 }
 
@@ -74,7 +83,7 @@ extension SignUpView {
     
     private func addSubviews() {
         [closeButton, emailLabel, emailTextField, nameLabel, nameTextField, passwordLabel, passwordTextField, verifyPasswordLabel, verifyPasswordTextField, doneButton, checkPasswordStackView].forEach ({ addSubview($0) })
-        [checkPasswordLabel_01, checkPasswordLabel_02, checkPasswordLabel_03, checkPasswordLabel_04].forEach({ checkPasswordStackView.addArrangedSubview($0) })
+        checkPasswordLabels.forEach({ checkPasswordStackView.addArrangedSubview($0) })
     }
     
     private func setupComponents() {
@@ -95,10 +104,11 @@ extension SignUpView {
     }
     
     private func setupEmail() {
+        let constraint = getConstraintForLabel(emailLabel)
         emailLabel
             .top(equalTo: closeButton.bottomAnchor, constant: 15)
             .left(equalTo: leadingAnchor, constant: 20)
-            .height(emailLabelHeightConstraint.constant)
+            .height(constraint.constant)
         emailTextField
             .top(equalTo: emailLabel.bottomAnchor, constant: 2)
             .left(equalTo: leadingAnchor, constant: 16)
@@ -107,30 +117,33 @@ extension SignUpView {
     }
     
     private func setupName() {
+        let constraint = getConstraintForLabel(nameLabel)
         nameLabel
             .top(equalTo: emailTextField.bottomAnchor, constant: 10)
             .applyConstraints(to: emailLabel, attributes: [.leading])
-            .height(nameLabelHeightConstraint.constant)
+            .height(constraint.constant)
         nameTextField
             .top(equalTo: nameLabel.bottomAnchor, constant: 2)
             .applyConstraints(to: emailTextField, attributes: [.leading, .trailing, .height])
     }
     
     private func setupPassword() {
+        let constraint = getConstraintForLabel(passwordLabel)
         passwordLabel
             .top(equalTo: nameTextField.bottomAnchor, constant: 10)
             .applyConstraints(to: emailLabel, attributes: [.leading])
-            .height(passwordLabelHeightConstraint.constant)
+            .height(constraint.constant)
         passwordTextField
             .top(equalTo: passwordLabel.bottomAnchor, constant: 2)
             .applyConstraints(to: emailTextField, attributes: [.leading, .trailing, .height])
     }
     
     private func setupVerifyPassword() {
+        let constraint = getConstraintForLabel(verifyPasswordLabel)
         verifyPasswordLabel
             .top(equalTo: passwordTextField.bottomAnchor, constant: 10)
             .applyConstraints(to: emailLabel, attributes: [.leading])
-            .height(verifyPasswordLabelHeightConstraint.constant)
+            .height(constraint.constant)
         verifyPasswordTextField
             .top(equalTo: verifyPasswordLabel.bottomAnchor, constant: 2)
             .applyConstraints(to: emailTextField, attributes: [.leading, .trailing, .height])

--- a/GIL/GIL/Screen/SignUp/SignUpView.swift
+++ b/GIL/GIL/Screen/SignUp/SignUpView.swift
@@ -32,7 +32,7 @@ final class SignUpView: UIView {
     // MARK: - Initialization
     override init(frame: CGRect) {
         super.init(frame: frame)
-        configureUI()
+        setupUI()
     }
     
     required init?(coder: NSCoder) {
@@ -64,89 +64,88 @@ extension SignUpView {
     }
 }
 
-// MARK: - Configure UI
+// MARK: - Setup UI
 extension SignUpView {
-    func configureUI() {
+    private func setupUI() {
         backgroundColor = .systemBackground
-        
-        configureLabel(emailLabel, text: "이메일")
-        configureLabel(nameLabel, text: "이름")
-        configureLabel(passwordLabel, text: "비밀번호")
-        configureLabel(verifyPasswordLabel, text: "비밀번호 확인")
-        
-        [closeButton, emailLabel, emailTextField, nameLabel, nameTextField, passwordLabel, passwordTextField, verifyPasswordLabel, verifyPasswordTextField, doneButton, checkPasswordStackView].forEach ({
-            addSubview($0)
-            $0.translatesAutoresizingMaskIntoConstraints = false
-        })
-        
-        [checkPasswordLabel_01, checkPasswordLabel_02, checkPasswordLabel_03, checkPasswordLabel_04].forEach({
-            checkPasswordStackView.addArrangedSubview($0)
-        })
+        addSubviews()
+        setupComponents()
     }
     
-    func makeConstraints() {
-        emailLabelHeightConstraint = emailLabel.heightAnchor.constraint(equalToConstant: 0)
-        nameLabelHeightConstraint = nameLabel.heightAnchor.constraint(equalToConstant: 0)
-        passwordLabelHeightConstraint = passwordLabel.heightAnchor.constraint(equalToConstant: 0)
-        verifyPasswordLabelHeightConstraint = verifyPasswordLabel.heightAnchor.constraint(equalToConstant: 0)
-        
-        NSLayoutConstraint.activate([
-            closeButton.topAnchor.constraint(equalTo: safeAreaLayoutGuide.topAnchor, constant: 10),
-            closeButton.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 10),
-            closeButton.widthAnchor.constraint(equalToConstant: 44),
-            closeButton.heightAnchor.constraint(equalToConstant: 44),
-            
-            emailLabel.topAnchor.constraint(equalTo: closeButton.bottomAnchor, constant: 15),
-            emailLabel.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 20),
-            emailLabelHeightConstraint,
-            
-            emailTextField.topAnchor.constraint(equalTo: emailLabel.bottomAnchor, constant: 2),
-            emailTextField.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 16),
-            emailTextField.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -16),
-            emailTextField.heightAnchor.constraint(equalToConstant: 60),
-            
-            nameLabel.topAnchor.constraint(equalTo: emailTextField.bottomAnchor, constant: 10),
-            nameLabel.leadingAnchor.constraint(equalTo: emailLabel.leadingAnchor),
-            nameLabelHeightConstraint,
-            
-            nameTextField.topAnchor.constraint(equalTo: nameLabel.bottomAnchor, constant: 2),
-            nameTextField.leadingAnchor.constraint(equalTo: emailTextField.leadingAnchor),
-            nameTextField.trailingAnchor.constraint(equalTo: emailTextField.trailingAnchor),
-            nameTextField.heightAnchor.constraint(equalTo: emailTextField.heightAnchor),
-            
-            passwordLabel.topAnchor.constraint(equalTo: nameTextField.bottomAnchor, constant: 10),
-            passwordLabel.leadingAnchor.constraint(equalTo: emailLabel.leadingAnchor),
-            passwordLabelHeightConstraint,
-            
-            passwordTextField.topAnchor.constraint(equalTo: passwordLabel.bottomAnchor, constant: 2),
-            passwordTextField.leadingAnchor.constraint(equalTo: nameTextField.leadingAnchor),
-            passwordTextField.trailingAnchor.constraint(equalTo: nameTextField.trailingAnchor),
-            passwordTextField.heightAnchor.constraint(equalTo: nameTextField.heightAnchor),
-            
-            verifyPasswordLabel.topAnchor.constraint(equalTo: passwordTextField.bottomAnchor, constant: 10),
-            verifyPasswordLabel.leadingAnchor.constraint(equalTo: emailLabel.leadingAnchor),
-            verifyPasswordLabelHeightConstraint,
-            
-            verifyPasswordTextField.topAnchor.constraint(equalTo: verifyPasswordLabel.bottomAnchor, constant: 2),
-            verifyPasswordTextField.leadingAnchor.constraint(equalTo: passwordTextField.leadingAnchor),
-            verifyPasswordTextField.trailingAnchor.constraint(equalTo: passwordTextField.trailingAnchor),
-            verifyPasswordTextField.heightAnchor.constraint(equalTo: passwordTextField.heightAnchor),
-            
-            checkPasswordStackView.topAnchor.constraint(equalTo: verifyPasswordTextField.bottomAnchor, constant: 15),
-            checkPasswordStackView.leadingAnchor.constraint(equalTo: verifyPasswordTextField.leadingAnchor, constant: 10),
-            checkPasswordStackView.trailingAnchor.constraint(equalTo: verifyPasswordTextField.trailingAnchor, constant: -10),
-            
-            doneButton.topAnchor.constraint(equalTo: checkPasswordStackView.bottomAnchor, constant: 30),
-            doneButton.leadingAnchor.constraint(equalTo: verifyPasswordTextField.leadingAnchor),
-            doneButton.trailingAnchor.constraint(equalTo: verifyPasswordTextField.trailingAnchor),
-            doneButton.heightAnchor.constraint(equalTo: verifyPasswordTextField.heightAnchor)
-        ])
+    private func addSubviews() {
+        [closeButton, emailLabel, emailTextField, nameLabel, nameTextField, passwordLabel, passwordTextField, verifyPasswordLabel, verifyPasswordTextField, doneButton, checkPasswordStackView].forEach ({ addSubview($0) })
+        [checkPasswordLabel_01, checkPasswordLabel_02, checkPasswordLabel_03, checkPasswordLabel_04].forEach({ checkPasswordStackView.addArrangedSubview($0) })
     }
     
-    private func configureLabel(_ label: UILabel, text: String) {
-        label.text = text.localized()
-        label.applyDynamicTypeFont(textStyle: .subheadline, size: 13, weight: .medium)
-        label.textColor = .mainGreen
-        label.alpha = 0
+    private func setupComponents() {
+        setupCloseButton()
+        setupEmail()
+        setupName()
+        setupPassword()
+        setupVerifyPassword()
+        setupCheckPasswordStackView()
+        setupDoneButton()
+    }
+    
+    private func setupCloseButton() {
+        closeButton
+            .top(equalTo: safeAreaLayoutGuide.topAnchor, constant: 10)
+            .left(equalTo: leadingAnchor, constant: 10)
+            .size(CGSize(width: 44, height: 44))
+    }
+    
+    private func setupEmail() {
+        emailLabel
+            .top(equalTo: closeButton.bottomAnchor, constant: 15)
+            .left(equalTo: leadingAnchor, constant: 20)
+            .height(emailLabelHeightConstraint.constant)
+        emailTextField
+            .top(equalTo: emailLabel.bottomAnchor, constant: 2)
+            .left(equalTo: leadingAnchor, constant: 16)
+            .right(equalTo: trailingAnchor, constant: -16)
+            .height(60)
+    }
+    
+    private func setupName() {
+        nameLabel
+            .top(equalTo: emailTextField.bottomAnchor, constant: 10)
+            .applyConstraints(to: emailLabel, attributes: [.leading])
+            .height(nameLabelHeightConstraint.constant)
+        nameTextField
+            .top(equalTo: nameLabel.bottomAnchor, constant: 2)
+            .applyConstraints(to: emailTextField, attributes: [.leading, .trailing, .height])
+    }
+    
+    private func setupPassword() {
+        passwordLabel
+            .top(equalTo: nameTextField.bottomAnchor, constant: 10)
+            .applyConstraints(to: emailLabel, attributes: [.leading])
+            .height(passwordLabelHeightConstraint.constant)
+        passwordTextField
+            .top(equalTo: passwordLabel.bottomAnchor, constant: 2)
+            .applyConstraints(to: emailTextField, attributes: [.leading, .trailing, .height])
+    }
+    
+    private func setupVerifyPassword() {
+        verifyPasswordLabel
+            .top(equalTo: passwordTextField.bottomAnchor, constant: 10)
+            .applyConstraints(to: emailLabel, attributes: [.leading])
+            .height(verifyPasswordLabelHeightConstraint.constant)
+        verifyPasswordTextField
+            .top(equalTo: verifyPasswordLabel.bottomAnchor, constant: 2)
+            .applyConstraints(to: emailTextField, attributes: [.leading, .trailing, .height])
+    }
+    
+    private func setupCheckPasswordStackView() {
+        checkPasswordStackView
+            .top(equalTo: verifyPasswordTextField.bottomAnchor, constant: 15)
+            .left(equalTo: verifyPasswordTextField.leadingAnchor, constant: 10)
+            .right(equalTo: verifyPasswordTextField.trailingAnchor, constant: -10)
+    }
+    
+    private func setupDoneButton() {
+        doneButton
+            .top(equalTo: checkPasswordStackView.bottomAnchor, constant: 30)
+            .applyConstraints(to: emailTextField, attributes: [.leading, .trailing, .height])
     }
 }

--- a/GIL/GIL/Screen/SignUp/signUpCollectionViewHandler.swift
+++ b/GIL/GIL/Screen/SignUp/signUpCollectionViewHandler.swift
@@ -39,10 +39,10 @@ final class SignUpCollectionViewHandler: NSObject, UITextFieldDelegate {
     func textFieldDidBeginEditing(_ textField: UITextField) {
         guard let signUpView = signUpView else { return }
         switch textField {
-        case signUpView.emailTextField: signUpView.animateLabelVisibility(signUpView.emailLabel, shouldShow: true, constraint: signUpView.emailLabelHeightConstraint)
-        case signUpView.nameTextField: signUpView.animateLabelVisibility(signUpView.nameLabel, shouldShow: true, constraint: signUpView.nameLabelHeightConstraint)
-        case signUpView.passwordTextField: signUpView.animateLabelVisibility(signUpView.passwordLabel, shouldShow: true, constraint: signUpView.passwordLabelHeightConstraint)
-        case signUpView.verifyPasswordTextField: signUpView.animateLabelVisibility(signUpView.verifyPasswordLabel, shouldShow: true, constraint: signUpView.verifyPasswordLabelHeightConstraint)
+        case signUpView.emailTextField: signUpView.animateLabelVisibility(signUpView.emailLabel, shouldShow: true)
+        case signUpView.nameTextField: signUpView.animateLabelVisibility(signUpView.nameLabel, shouldShow: true)
+        case signUpView.passwordTextField: signUpView.animateLabelVisibility(signUpView.passwordLabel, shouldShow: true)
+        case signUpView.verifyPasswordTextField: signUpView.animateLabelVisibility(signUpView.verifyPasswordLabel, shouldShow: true)
         default: break
         }
     }
@@ -50,10 +50,10 @@ final class SignUpCollectionViewHandler: NSObject, UITextFieldDelegate {
     func textFieldDidEndEditing(_ textField: UITextField) {
         guard let signUpView = signUpView else { return }
         switch textField {
-        case signUpView.emailTextField: signUpView.animateLabelVisibility(signUpView.emailLabel, shouldShow: false, constraint: signUpView.emailLabelHeightConstraint)
-        case signUpView.nameTextField: signUpView.animateLabelVisibility(signUpView.nameLabel, shouldShow: false, constraint: signUpView.nameLabelHeightConstraint)
-        case signUpView.passwordTextField: signUpView.animateLabelVisibility(signUpView.passwordLabel, shouldShow: false, constraint: signUpView.passwordLabelHeightConstraint)
-        case signUpView.verifyPasswordTextField: signUpView.animateLabelVisibility(signUpView.verifyPasswordLabel, shouldShow: false, constraint: signUpView.verifyPasswordLabelHeightConstraint)
+        case signUpView.emailTextField: signUpView.animateLabelVisibility(signUpView.emailLabel, shouldShow: false)
+        case signUpView.nameTextField: signUpView.animateLabelVisibility(signUpView.nameLabel, shouldShow: false)
+        case signUpView.passwordTextField: signUpView.animateLabelVisibility(signUpView.passwordLabel, shouldShow: false)
+        case signUpView.verifyPasswordTextField: signUpView.animateLabelVisibility(signUpView.verifyPasswordLabel, shouldShow: false)
         default: break
         }
     }


### PR DESCRIPTION
UIView의 확장을 통해 뷰 레이아웃을 관리하기 위한 메서드를 추가했습니다.
NSMapTable을 활용하여 UIView와 관련된 제약 조건들을 연결했고 weakMemory 옵션을 사용하여 뷰가 메모리에서 해제될 때 자동으로 제약 조건을 정리합니다.
메서드를 통해 뷰에 연결된 제약 조건을 업데이트할 수 있습니다.
모든 뷰의 레이아웃 제약 조건 관련 코드를 수정했습니다.